### PR TITLE
Use Vite instead of react-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,12 @@
     "mapbox-gl": "^2.15.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "@vitejs/plugin-react": "^5.0.0",
+    "vite": "^7.1.2"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "start": "vite",
+    "build": "vite build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- replace react-scripts with Vite and plugin
- update scripts for Vite build and dev

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0ae3c48388327918f85a72e972ae1