### PR TITLE
Display avatars on map markers

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,17 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 /* Map container */
 .map { width: 100vw; height: 100vh; }
 
+/* Map user marker */
+.marker-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background-size: cover;
+  background-position: center;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 2px rgba(0,0,0,.1);
+}
+
 /* Buttons */
 .btn {
   appearance: none;


### PR DESCRIPTION
## Summary
- show user photos in map markers using a custom HTML element
- fall back to colored circle markers when no photo is available
- refresh marker appearance when avatars change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bf70a4b8832783179b5bae70cba1