### PR TITLE
Remove leftover markers with missing location

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -220,7 +220,13 @@ export default function App() {
 
       // aktualizace / přidání markerů
       Object.entries(data).forEach(([uid, u]) => {
-        if (!u.lat || !u.lng) return;
+        if (!u.lat || !u.lng) {
+          if (markers.current[uid]) {
+            markers.current[uid].remove();
+            delete markers.current[uid];
+          }
+          return;
+        }
 
         // styl podle stavu
         const isMe = uid === me.uid;


### PR DESCRIPTION
## Summary
- remove markers when their user has no coordinates to avoid duplicated gray markers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a16e535990832792b4e508a26e4777