### PR TITLE
Ensure map markers stay anchored when details bubble is open

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,11 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 .map { width: 100vw; height: 100vh; }
 
 /* Map user marker */
-.marker-wrapper { position: relative; }
+.marker-wrapper {
+  position: relative;
+  width: 32px;
+  height: 32px;
+}
 .marker-avatar {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- fix marker shifting by giving marker wrapper a fixed size

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a17d6f3f108327b80481d8c4796105