### PR TITLE
style: add circular expanding map markers

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,30 +24,32 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 .marker-bubble {
   position: absolute;
-  bottom: 100%;
+  top: 50%;
   left: 50%;
-  transform: translate(-50%, -8px);
+  width: 160px;
+  height: 160px;
   background: #fff;
-  border-radius: 14px;
+  border-radius: 50%;
   box-shadow: 0 2px 10px rgba(0,0,0,.15);
   padding: 12px;
-  width: 180px;
   text-align: center;
-  display: none;
   font: 12px/1.45 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   z-index: 10;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.2s ease, opacity 0.2s ease;
 }
-.marker-bubble::after {
-  content: "";
-  position: absolute;
-  bottom: -10px;
-  left: 50%;
-  transform: translateX(-50%);
-  border-width: 10px;
-  border-style: solid;
-  border-color: #fff transparent transparent transparent;
+.marker-bubble::after { display: none; }
+.marker-wrapper.active .marker-bubble {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  pointer-events: auto;
 }
-.marker-wrapper.active .marker-bubble { display: block; }
 .marker-wrapper.active .marker-avatar { display: none; }
 .bubble-img {
   width: 56px;


### PR DESCRIPTION
## Summary
- redesign marker popup into circular bubble
- add scale animation and hide avatar when bubble expands

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a18ef04e588327a5ab501cf166f288