### PR TITLE
Expand map bubble and reposition profile details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -449,15 +449,18 @@ export default function App() {
     }
     root.appendChild(img);
 
+    const bottom = document.createElement("div");
+    bottom.className = "bubble-bottom";
+
     const nameDiv = document.createElement("div");
     nameDiv.className = "bubble-name";
     nameDiv.textContent = name + (meVsOther ? " (ty)" : "");
-    root.appendChild(nameDiv);
+    bottom.appendChild(nameDiv);
 
     const infoDiv = document.createElement("div");
     infoDiv.className = "bubble-info";
     infoDiv.textContent = meVsOther ? "teď" : `Naposledy online: ${last}`;
-    root.appendChild(infoDiv);
+    bottom.appendChild(infoDiv);
 
     if (!meVsOther) {
       const actions = document.createElement("div");
@@ -472,8 +475,10 @@ export default function App() {
         chatBtn.textContent = "💬 Chat";
         actions.appendChild(chatBtn);
       }
-      root.appendChild(actions);
+      bottom.appendChild(actions);
     }
+
+    root.appendChild(bottom);
 
     return root;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -26,19 +26,20 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 160px;
-  height: 160px;
+  width: 220px;
+  height: 220px;
   background: #fff;
   border-radius: 50%;
   box-shadow: 0 2px 10px rgba(0,0,0,.15);
-  padding: 12px;
   text-align: center;
   font: 12px/1.45 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   z-index: 10;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
+  justify-content: flex-start;
+  padding: 0;
+  overflow: hidden;
   transform: translate(-50%, -50%) scale(0);
   opacity: 0;
   pointer-events: none;
@@ -52,25 +53,35 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 .marker-wrapper.active .marker-avatar { display: none; }
 .bubble-img {
-  width: 56px;
-  height: 56px;
+  width: 75%;
+  height: 75%;
+  flex: 0 0 75%;
   border-radius: 50%;
   object-fit: cover;
   display: block;
-  margin: 0 auto 6px;
+  margin: 0 auto;
   border: 1px solid #e5e7eb;
 }
 .bubble-img.empty { background: #f3f4f6; }
+.bubble-bottom {
+  flex: 0 0 25%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 4px 8px;
+}
 .bubble-name { font-weight: 700; }
 .bubble-info { color: #6b7280; margin-top: 2px; }
-.bubble-actions { margin-top: 8px; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
+.bubble-actions { margin-top: 4px; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
 .bubble-actions button {
-  padding: 6px 10px;
+  padding: 4px 8px;
   border: 1px solid #ccc;
   border-radius: 8px;
   background: #fff;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 12px;
 }
 
 /* Buttons */


### PR DESCRIPTION
## Summary
- enlarge marker profile bubble and move content into defined top and bottom sections
- place the circular avatar from the lower quarter up and position name, status, and buttons in the bottom quarter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a193559efc8327929987176f23629f