### PR TITLE
feat: play sound for incoming chat messages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,6 +94,8 @@ export default function App() {
 
   // zvuk pomocí Web Audio API
   const audioCtx = useRef(null);
+  const lastMsgRef = useRef({}); // pairId -> last message id
+  const msgsLoaded = useRef(false);
 
   useEffect(() => {
     audioCtx.current = new (window.AudioContext || window.webkitAudioContext)();
@@ -362,6 +364,38 @@ export default function App() {
     return () => unsub();
   }, [me]);
 
+  // zvuk při nové zprávě, i když není chat otevřený
+  useEffect(() => {
+    if (!me) return;
+    const msgsRef = ref(db, "messages");
+    const unsub = onValue(msgsRef, (snap) => {
+      const data = snap.val() || {};
+      const prev = lastMsgRef.current;
+      const next = { ...prev };
+      Object.entries(data).forEach(([pid, msgs]) => {
+        const [a, b] = pid.split("_");
+        if (a !== me.uid && b !== me.uid) return;
+        const arr = Object.entries(msgs)
+          .sort((a, b) => (a[1].time || 0) - (b[1].time || 0));
+        const last = arr[arr.length - 1];
+        if (!last) return;
+        const [id, m] = last;
+        if (
+          msgsLoaded.current &&
+          prev[pid] !== id &&
+          m.from !== me.uid &&
+          soundEnabled
+        ) {
+          beep(660);
+        }
+        next[pid] = id;
+      });
+      lastMsgRef.current = next;
+      msgsLoaded.current = true;
+    });
+    return () => unsub();
+  }, [me, soundEnabled]);
+
   // aktualizace bublin při změně pingů nebo uživatelů
   useEffect(() => {
     Object.entries(markers.current).forEach(([uid, mk]) => {
@@ -576,10 +610,6 @@ export default function App() {
         .map(([id, m]) => ({ id, ...m }))
         .sort((a, b) => (a.time || 0) - (b.time || 0));
       setChatMsgs(arr);
-      const last = arr[arr.length - 1];
-      if (last && last.from !== me.uid && soundEnabled) {
-        beep(660);
-      }
     });
     chatUnsub.current = unsub;
     return () => {


### PR DESCRIPTION
## Summary
- track last message per conversation
- beep when a new message arrives even if chat is closed
- ensure the first message after loading also triggers a beep

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1b9d176d483279d0f64574049507d