### PR TITLE
Keep message highlight until chat is opened

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -387,13 +387,6 @@ export default function App() {
         ) {
           beep(660);
           setMarkerHighlights((prev) => ({ ...prev, [m.from]: "purple" }));
-          setTimeout(() => {
-            setMarkerHighlights((prev) => {
-              const copy = { ...prev };
-              if (copy[m.from] === "purple") delete copy[m.from];
-              return copy;
-            });
-          }, 5000);
         }
         next[pid] = id;
       });
@@ -640,6 +633,11 @@ export default function App() {
       return;
     }
     setOpenChatWith(uid);
+    setMarkerHighlights((prev) => {
+      const copy = { ...prev };
+      delete copy[uid];
+      return copy;
+    });
   }
 
   async function sendMessage() {


### PR DESCRIPTION
## Summary
- keep message marker highlight active until the corresponding chat is opened
- clear highlight when opening a chat with that user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1e26aa7088327aa32b19599957786