### PR TITLE
feat: keep map centered when viewing photos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -477,6 +477,25 @@ export default function App() {
       : "0 0 0 2px rgba(0,0,0,.1)";
   }
 
+  function freezeMap(center) {
+    if (!map) return;
+    if (center) {
+      map.setCenter(center);
+    }
+    map.dragPan.disable();
+    map.scrollZoom.disable();
+    map.doubleClickZoom.disable();
+    map.touchZoomRotate.disable();
+  }
+
+  function unfreezeMap() {
+    if (!map) return;
+    map.dragPan.enable();
+    map.scrollZoom.enable();
+    map.doubleClickZoom.enable();
+    map.touchZoomRotate.enable();
+  }
+
   function toggleBubble(uid) {
     if (openBubble.current && openBubble.current !== uid) {
       closeBubble(openBubble.current);
@@ -488,9 +507,11 @@ export default function App() {
     if (active) {
       el.classList.remove("active");
       openBubble.current = null;
+      unfreezeMap();
     } else {
       el.classList.add("active");
       openBubble.current = uid;
+      freezeMap(mk.getLngLat());
       wireBubbleButtons(uid);
     }
   }
@@ -499,6 +520,7 @@ export default function App() {
     const mk = markers.current[uid];
     if (!mk) return;
     mk.getElement().classList.remove("active");
+    unfreezeMap();
   }
 
   function getBubbleContent({ uid, name, photos, photoURL }) {


### PR DESCRIPTION
## Summary
- Lock the map in place when a marker bubble is opened, centering on that marker
- Re-enable map interaction after the bubble is closed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1fc4b107083279ee5d310fef500f2