### PR TITLE
fix: preserve marker gallery scroll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -298,6 +298,8 @@ export default function App() {
           );
 
           const oldBubble = wrapper.querySelector(".marker-bubble");
+          const scrollLeft =
+            oldBubble?.querySelector(".bubble-gallery")?.scrollLeft || 0;
           const newBubble = getBubbleContent({
             uid,
             name: u.name || "Anonym",
@@ -305,6 +307,8 @@ export default function App() {
             photoURL: u.photoURL,
           });
           wrapper.replaceChild(newBubble, oldBubble);
+          const newGallery = newBubble.querySelector(".bubble-gallery");
+          if (newGallery) newGallery.scrollLeft = scrollLeft;
           if (wrapper.classList.contains("active")) {
             wireBubbleButtons(uid);
           }


### PR DESCRIPTION
## Summary
- keep marker photo gallery position while updating markers to prevent jump back to first image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2081b83408327bfefe360b4c7ad21