### PR TITLE
Fix swipe handling in marker photo gallery

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -573,6 +573,9 @@ export default function App() {
 
     const gallery = document.createElement("div");
     gallery.className = "bubble-gallery";
+    ["touchstart", "touchmove", "pointerdown", "pointermove"].forEach((ev) =>
+      gallery.addEventListener(ev, (e) => e.stopPropagation())
+    );
     if (list.length === 0) {
       const placeholder = document.createElement("div");
       placeholder.className = "bubble-photo empty";

--- a/src/index.css
+++ b/src/index.css
@@ -53,14 +53,15 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 .marker-wrapper.active .marker-avatar { display: none; }
 .bubble-gallery {
-  width: 75%;
-  height: 75%;
-  flex: 0 0 75%;
-  display: flex;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scroll-snap-type: x mandatory;
-  border-radius: 50%;
+    width: 75%;
+    height: 75%;
+    flex: 0 0 75%;
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    border-radius: 50%;
+    touch-action: pan-y;
 }
 .bubble-photo {
   flex: 0 0 100%;


### PR DESCRIPTION
## Summary
- prevent marker bubble gallery gestures from bubbling to map
- allow swipe scrolling of gallery on touch devices

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a210ad187483278d225acb9c263751