### PR TITLE
Remove duplicate sound toggle button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -833,22 +833,6 @@ export default function App() {
           <>
             <button
               onClick={() => {
-                toggleSound();
-                setFabOpen(false);
-              }}
-              style={{
-                padding: "8px 10px",
-                borderRadius: 10,
-                border: "1px solid #ddd",
-                background: "#fff",
-                cursor: "pointer",
-              }}
-              title={soundEnabled ? "Vypnout zvuk" : "Zapnout zvuk"}
-            >
-              {soundEnabled ? "🔊" : "🔇"}
-            </button>
-            <button
-              onClick={() => {
                 setShowSettings(true);
                 setFabOpen(false);
               }}


### PR DESCRIPTION
## Summary
- Remove sound toggle from floating menu, keeping settings, gallery and chat options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a214d11d58832782853692947dd923