### PR TITLE
feat: show black marker for users without photos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -274,7 +274,8 @@ export default function App() {
         }
 
         const highlight = markerHighlightsRef.current[uid];
-        const baseColor = isMe ? "red" : "#147af3";
+        const hasPhoto = !!((u.photos && u.photos[0]) || u.photoURL);
+        const baseColor = hasPhoto ? (isMe ? "red" : "#147af3") : "black";
         const draggable = false;
 
         if (!markers.current[uid]) {
@@ -473,7 +474,8 @@ export default function App() {
       }
 
       const highlight = markerHighlights[uid];
-      const baseColor = isMe ? "red" : "#147af3";
+      const hasPhoto = !!((u.photos && u.photos[0]) || u.photoURL);
+      const baseColor = hasPhoto ? (isMe ? "red" : "#147af3") : "black";
       const avatar = wrapper.querySelector(".marker-avatar");
       setMarkerAppearance(
         avatar,


### PR DESCRIPTION
## Summary
- display black map marker for users who have not uploaded a photo
- keep updated marker coloring during refreshes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2193c4bfc83278af1b6c9d5d578f0