### PR TITLE
Resize menu icons and remove background

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -873,11 +873,14 @@ export default function App() {
                 setFabOpen(false);
               }}
               style={{
-                padding: "8px 10px",
-                borderRadius: 10,
+                width: 48,
+                height: 48,
+                borderRadius: 24,
                 border: "1px solid #ddd",
-                background: "#fff",
+                background: "transparent",
                 cursor: "pointer",
+                fontSize: 24,
+                lineHeight: "24px",
               }}
               title="Nastavení"
             >
@@ -889,11 +892,14 @@ export default function App() {
                 setFabOpen(false);
               }}
               style={{
-                padding: "8px 10px",
-                borderRadius: 10,
+                width: 48,
+                height: 48,
+                borderRadius: 24,
                 border: "1px solid #ddd",
-                background: "#fff",
+                background: "transparent",
                 cursor: "pointer",
+                fontSize: 24,
+                lineHeight: "24px",
               }}
               title="Galerie"
             >

--- a/src/index.css
+++ b/src/index.css
@@ -258,20 +258,20 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 /* FAB chat history button */
 .fab-chat {
   position: relative;
-  padding: 8px 10px;
+  width: 48px;
+  height: 48px;
   border: 1px solid #ddd;
-  background: #ffe5e5;
-  border-radius: 16px;
+  background: transparent;
+  border-radius: 24px;
   cursor: pointer;
+  font-size: 24px;
+  line-height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .fab-chat::after {
-  content: "";
-  position: absolute;
-  bottom: -6px;
-  right: 12px;
-  border-width: 6px 6px 0 6px;
-  border-style: solid;
-  border-color: #ffe5e5 transparent transparent transparent;
+  display: none;
 }
 
 /* Chat history bubble */


### PR DESCRIPTION
## Summary
- Enlarge settings, gallery, and chat buttons in the floating menu
- Remove white backgrounds for cleaner transparent look

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a226f187ec83279b3fe8fe6553e434