### PR TITLE
Fix photo swipe in marker gallery

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -83,7 +83,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
     overflow-y: hidden;
     scroll-snap-type: x mandatory;
     border-radius: 50%;
-    touch-action: pan-y;
+    touch-action: pan-x;
 }
 .bubble-photo {
   flex: 0 0 100%;


### PR DESCRIPTION
## Summary
- enable horizontal swiping in marker photo gallery by allowing pan-x touch action

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23dfb9b0c8327ab21b557797b2664