### PR TITLE
Add startup splash screen that reveals map on click

### DIFF
--- a/public/splash.svg
+++ b/public/splash.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 500">
+  <rect width="375" height="500" fill="#ff8fa5"/>
+  <g transform="translate(120 80)">
+    <path d="M67.5 0C30.2 0 0 30.2 0 67.5c0 54 67.5 144 67.5 144S135 121.5 135 67.5C135 30.2 104.8 0 67.5 0z" fill="#000"/>
+    <path d="M67.5 32c-13-11-34-11-47 0-13 11-13 30 0 41l47 47 47-47c13-11 13-30 0-41-13-11-34-11-47 0z" fill="#ff8fa5"/>
+  </g>
+  <text x="50%" y="380" text-anchor="middle" font-family="Arial, sans-serif" font-size="72" fill="#000">PutPing</text>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,6 +73,8 @@ export default function App() {
   const [showChatList, setShowChatList] = useState(false);
   const [showGallery, setShowGallery] = useState(false);
   const [deleteIdx, setDeleteIdx] = useState(null);
+  const [showIntro, setShowIntro] = useState(true);
+  const [fadeIntro, setFadeIntro] = useState(false);
   const [markerHighlights, setMarkerHighlights] = useState({}); // uid -> color
   const [locationConsent, setLocationConsent] = useState(() =>
     localStorage.getItem("locationConsent") === "1"
@@ -1349,6 +1351,17 @@ export default function App() {
               </button>
             </div>
           </div>
+        </div>
+      )}
+      {showIntro && (
+        <div
+          className={`intro-screen ${fadeIntro ? "intro-screen--hidden" : ""}`}
+          onClick={() => {
+            setFadeIntro(true);
+            setTimeout(() => setShowIntro(false), 500);
+          }}
+        >
+          <img src="/splash.svg" alt="PutPing" className="intro-screen__img" />
         </div>
       )}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,25 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 /* Map container */
 .map { width: 100vw; height: 100vh; }
 
+/* Intro splash */
+.intro-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  transition: opacity 0.5s ease;
+}
+.intro-screen--hidden {
+  opacity: 0;
+}
+.intro-screen__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 /* Location consent modal */
 .consent-modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- Show the PutPing splash image across the screen when the app loads
- Fade out the splash image on click to reveal the map

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2448f8b4483278c6c726e2227e7dc