### PR TITLE
Use splash.jpg for intro splash screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1361,7 +1361,7 @@ export default function App() {
             setTimeout(() => setShowIntro(false), 500);
           }}
         >
-          <img src="/splash.svg" alt="PutPing" className="intro-screen__img" />
+          <img src="/splash.jpg" alt="PutPing" className="intro-screen__img" />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- display intro splash screen using splash.jpg instead of splash.svg

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a249055918832785eb53a708818541