### PR TITLE
Add margin around splash screen image

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   justify-content: center;
   z-index: 1000;
   transition: opacity 0.5s ease;
+  padding: 1cm;
 }
 .intro-screen--hidden {
   opacity: 0;
@@ -22,7 +23,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 .intro-screen__img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 /* Location consent modal */


### PR DESCRIPTION
## Summary
- ensure intro splash image leaves a 1cm margin on all sides
- contain splash image to prevent text clipping

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2b1752e848327b274b6aec31897fd