### PR TITLE
Adjust splash padding and background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,8 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   justify-content: center;
   z-index: 1000;
   transition: opacity 0.5s ease;
-  padding: 1cm;
+  padding: 7mm;
+  background: #ff8fa1;
 }
 .intro-screen--hidden {
   opacity: 0;


### PR DESCRIPTION
## Summary
- Adjust splash overlay to pad content 7mm from edges
- Fill unused screen space with splash background color to hide map

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2b86cb8848327937c751f6f4c4cc6