### PR TITLE
Handle geolocation errors by clearing location

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -236,6 +236,12 @@ export default function App() {
     };
     const handleErr = (err) => {
       console.warn("Geolocation error", err);
+      update(meRef, {
+        lat: null,
+        lng: null,
+        lastActive: Date.now(),
+        online: false,
+      });
     };
 
     // iOS may not trigger watchPosition immediately; request current position once


### PR DESCRIPTION
## Summary
- Clear stored location and mark user offline if geolocation fails, preventing stale positions from being shown

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a330d6633c8327abc014d851cc1a83