### PR TITLE
Ignore inaccurate geolocation readings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -226,7 +226,12 @@ export default function App() {
     const opts = { enableHighAccuracy: true, maximumAge: 5000, timeout: 10000 };
 
     const updatePos = (pos) => {
-      const { latitude, longitude } = pos.coords;
+      const { latitude, longitude, accuracy } = pos.coords;
+      // Ignore obviously wrong positions when the device reports very low accuracy
+      if (accuracy && accuracy > 1000) {
+        console.warn("Ignoring low-accuracy position", accuracy);
+        return;
+      }
       update(meRef, {
         lat: latitude,
         lng: longitude,


### PR DESCRIPTION
## Summary
- skip geolocation updates when the browser reports very low accuracy, avoiding stale or wrong user positions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3356cb3ec8327a1b824483f4eca90