### PR TITLE
fix: allow coarse location updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -227,8 +227,8 @@ export default function App() {
 
     const updatePos = (pos) => {
       const { latitude, longitude, accuracy } = pos.coords;
-      // Ignore obviously wrong positions when the device reports very low accuracy
-      if (accuracy && accuracy > 1000) {
+      // Ignore obviously wrong positions with extremely low accuracy (>10 km)
+      if (accuracy && accuracy > 10_000) {
         console.warn("Ignoring low-accuracy position", accuracy);
         return;
       }


### PR DESCRIPTION
## Summary
- allow coarse geolocation updates by accepting accuracy up to 10km

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a33addc5bc8327a7b8c28e5e83d67f