### PR TITLE
Handle low-accuracy geolocation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -228,9 +228,14 @@ export default function App() {
 
     const updatePos = (pos) => {
       const { latitude, longitude, accuracy } = pos.coords;
+      console.log("Position accuracy", accuracy);
       // Ignore obviously wrong positions with extremely low accuracy (>10 km)
       if (accuracy && accuracy > 10_000) {
         console.warn("Ignoring low-accuracy position", accuracy);
+        update(meRef, {
+          lastActive: Date.now(),
+          online: true,
+        });
         return;
       }
       update(meRef, {


### PR DESCRIPTION
## Summary
- log reported geolocation accuracy
- record lastActive when position accuracy is too low to update coordinates

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36af7bc1c832782ef78789729821e