### PR TITLE
feat: add integrated ping button to marker

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -692,7 +692,9 @@ export default function App() {
         actionBtn.textContent = "💬 Chat";
         actionBtn.dataset.action = "chat";
       } else {
-        actionBtn.textContent = "📩 Ping";
+        actionBtn.className = "ping-btn";
+        actionBtn.innerHTML =
+          '<svg class="ping-btn__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14"><path d="M12 24a2.5 2.5 0 0 0 2.45-2h-4.9A2.5 2.5 0 0 0 12 24Zm6.36-6v-5a6.36 6.36 0 0 0-4.86-6.18V6a1.5 1.5 0 1 0-3 0v.82A6.36 6.36 0 0 0 5.64 13v5l-1.5 1.5v1h15.72v-1Z" fill="currentColor"/></svg><span class="ping-btn__text">Ping</span>';
         actionBtn.dataset.action = "ping";
       }
       actions.appendChild(actionBtn);

--- a/src/index.css
+++ b/src/index.css
@@ -131,12 +131,18 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   width: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  padding: 4px 8px;
+  padding: 4px 8px 12px;
 }
 .bubble-name { font-weight: 700; }
-.bubble-actions { margin-top: 2px; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
+.bubble-actions {
+  margin-top: auto;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
 .bubble-actions button {
   padding: 4px 8px;
   border: 1px solid #ccc;
@@ -145,6 +151,24 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   cursor: pointer;
   font-size: 12px;
 }
+
+.bubble-actions .ping-btn {
+  padding: 0 16px;
+  height: 32px;
+  border: none;
+  border-radius: 0;
+  background: linear-gradient(180deg, #FF3366, #FF6F91);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  cursor: pointer;
+  clip-path: path('M0 6C0 2.7 2.7 0 6 0H94C97.3 0 100 2.7 100 6V22C100 28 75 32 50 32C25 32 0 28 0 22Z');
+}
+.bubble-actions .ping-btn:hover { filter: brightness(1.05); }
+.bubble-actions .ping-btn:active { transform: translateY(1px); }
+.bubble-actions .ping-btn__icon { margin-right: 4px; }
 
 /* Buttons */
 .btn {


### PR DESCRIPTION
## Summary
- add ping action button with bell icon to marker bubble
- style ping button as tapered pill with pink gradient and bottom placement

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a37edc833483279a38111e7ea156cd