### PR TITLE
style: add white frame to marker photo

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -122,8 +122,9 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   height: 100%;
   object-fit: cover;
   scroll-snap-align: center;
-  border: 1px solid #e5e7eb;
+  border: 4px solid #fff;
   border-radius: 50%;
+  box-sizing: border-box;
 }
 .bubble-photo.empty { background: #f3f4f6; }
 .bubble-bottom {


### PR DESCRIPTION
## Summary
- create a circular white border around marker popup photos

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a381156a3c832788d2b4751b6566a4