### PR TITLE
Adjust marker photo positioning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -127,6 +127,9 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   box-sizing: border-box;
 }
 .bubble-photo.empty { background: #f3f4f6; }
+.marker-wrapper.active img.bubble-photo {
+  transform: translateY(10%);
+}
 .bubble-bottom {
   flex: 0 0 25%;
   width: 100%;


### PR DESCRIPTION
## Summary
- Shift marker's open photo downward by 10% of its diameter for better framing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3827b765c8327904e605e50065605