### PR TITLE
Add animated ping/chat button at teardrop tip

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -688,15 +688,24 @@ export default function App() {
 
       const actionBtn = document.createElement("button");
       actionBtn.id = `btnAction_${uid}`;
+      actionBtn.className = "ping-btn";
+      actionBtn.dataset.action = canChat ? "chat" : "ping";
+      actionBtn.innerHTML =
+        '<span class="ping-btn__text ping-btn__text--ping">🔔 Ping</span>' +
+        '<span class="ping-btn__text ping-btn__text--chat">💬 Chat</span>';
+
+      const pingText = actionBtn.querySelector(
+        ".ping-btn__text--ping"
+      );
+      const chatText = actionBtn.querySelector(
+        ".ping-btn__text--chat"
+      );
       if (canChat) {
-        actionBtn.textContent = "💬 Chat";
-        actionBtn.dataset.action = "chat";
+        chatText.classList.add("visible");
       } else {
-        actionBtn.className = "ping-btn";
-        actionBtn.innerHTML =
-          '<svg class="ping-btn__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14"><path d="M12 24a2.5 2.5 0 0 0 2.45-2h-4.9A2.5 2.5 0 0 0 12 24Zm6.36-6v-5a6.36 6.36 0 0 0-4.86-6.18V6a1.5 1.5 0 1 0-3 0v.82A6.36 6.36 0 0 0 5.64 13v5l-1.5 1.5v1h15.72v-1Z" fill="currentColor"/></svg><span class="ping-btn__text">Ping</span>';
-        actionBtn.dataset.action = "ping";
+        pingText.classList.add("visible");
       }
+
       actions.appendChild(actionBtn);
 
       bottom.appendChild(actions);

--- a/src/index.css
+++ b/src/index.css
@@ -159,6 +159,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 .bubble-actions {
   margin-top: auto;
+  margin-bottom: -4px;
   display: flex;
   gap: 8px;
   justify-content: center;
@@ -173,6 +174,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   font-size: 12px;
 }
 
+
 .bubble-actions .ping-btn {
   padding: 0 16px;
   height: 32px;
@@ -180,16 +182,47 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   border-radius: 0;
   background: linear-gradient(180deg, #FF3366, #FF6F91);
   color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   font-size: 12px;
   cursor: pointer;
   clip-path: path('M0 6C0 2.7 2.7 0 6 0H94C97.3 0 100 2.7 100 6V22C100 28 75 32 50 32C25 32 0 28 0 22Z');
+  position: relative;
+  overflow: hidden;
 }
 .bubble-actions .ping-btn:hover { filter: brightness(1.05); }
 .bubble-actions .ping-btn:active { transform: translateY(1px); }
-.bubble-actions .ping-btn__icon { margin-right: 4px; }
+.bubble-actions .ping-btn[data-action="chat"] {
+  background: linear-gradient(180deg, #3B82F6, #60A5FA);
+}
+
+.ping-btn__text {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%) scale(0.9);
+  opacity: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.ping-btn__text.visible {
+  animation: ping-text-in 0.2s ease forwards;
+}
+
+@keyframes ping-text-in {
+  from {
+    opacity: 0;
+    transform: translateY(-50%) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+  }
+}
 
 /* Buttons */
 .btn {


### PR DESCRIPTION
## Summary
- Replace static ping button with toggleable Ping/Chat button that swaps modes after mutual ping
- Position Ping/Chat button at teardrop tip with gradients for Ping and Chat states
- Add fade/scale animation for smooth text transitions

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a38b6b766083279cb95c17de999b68