### PR TITLE
feat: embed triangular ping button into marker

### DIFF
--- a/src/PinSVG.tsx
+++ b/src/PinSVG.tsx
@@ -92,26 +92,21 @@ const PinSVG: React.FC<PinSVGProps> = ({ photoUrl, name, onPing }) => {
         aria-label={aria}
         style={{ cursor: "pointer" }}
       >
-        <rect
-          x="70"
-          y="240"
-          width="100"
-          height="40"
-          rx="10"
-          ry="10"
+        <polygon
+          points="70,260 170,260 120,320"
           fill={`url(#${buttonGradient})`}
         />
         <circle
           key={rippleKey}
           cx="120"
-          cy="260"
+          cy="280"
           r="30"
           fill={rippleColor}
           className="pin-ripple"
         />
         <text
           x="120"
-          y="260"
+          y="280"
           textAnchor="middle"
           dominantBaseline="middle"
           className={`pin-btn-text ${mode === "ping" ? "visible" : "hidden"}`}
@@ -120,7 +115,7 @@ const PinSVG: React.FC<PinSVGProps> = ({ photoUrl, name, onPing }) => {
         </text>
         <text
           x="120"
-          y="260"
+          y="280"
           textAnchor="middle"
           dominantBaseline="middle"
           className={`pin-btn-text ${mode === "chat" ? "visible" : "hidden"}`}


### PR DESCRIPTION
## Summary
- replace rectangular ping/chat button with triangle aligned to marker tip
- adjust ping ripples and text positions for new triangle layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a419ceacc08327900c748e0e5fd6e2