### PR TITLE
feat: switch ping button to chat immediately

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -727,6 +727,13 @@ export default function App() {
           openChat(uid);
         } else {
           sendPing(uid);
+          btn.dataset.action = "chat";
+          btn
+            .querySelector(".ping-btn__text--ping")
+            ?.classList.remove("visible");
+          btn
+            .querySelector(".ping-btn__text--chat")
+            ?.classList.add("visible");
         }
       };
   }


### PR DESCRIPTION
## Summary
- switch ping button to chat state immediately after sending ping

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4cdef78488327a3c0038fd63f5c72