### PR TITLE
Ensure marker wrapper uses bottom-center origin

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -338,6 +338,7 @@ export default function App() {
         if (!markers.current[uid]) {
           const wrapper = document.createElement("div");
           wrapper.className = "marker-wrapper";
+          wrapper.style.transformOrigin = "bottom center";
           const avatar = document.createElement("div");
           avatar.className = "marker-avatar";
           setMarkerAppearance(


### PR DESCRIPTION
## Summary
- Add bottom-center transform origin on marker wrapper element
- Confirm mapbox marker uses wrapper element with draggable option and bottom anchor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d07ecb948327b36c451ed1c2d1f8