### PR TITLE
feat(firebase): export config and support secondary apps

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -15,11 +15,13 @@ const firebaseConfig = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 				
-const app = initializeApp(firebaseConfig);				
-				
-const db = getDatabase(app);				
-const auth = getAuth(app);				
-const storage = getStorage(app);				
-				
-// ⬇️ JEDEN společný export – žádné další exporty v tomhle souboru				
-export { db, auth, storage };				
+const app = initializeApp(firebaseConfig);
+
+const db = getDatabase(app);
+const auth = getAuth(app);
+const storage = getStorage(app);
+
+const initSecondaryApp = (name) => initializeApp(firebaseConfig, name);
+
+// ⬇️ JEDEN společný export – žádné další exporty v tomhle souboru
+export { db, auth, storage, firebaseConfig, initSecondaryApp };


### PR DESCRIPTION
## Summary
- export `firebaseConfig` from firebase module
- add `initSecondaryApp` helper to initialize named Firebase app instances

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d279de5c8327a5fc2195c3d32d0f