### PR TITLE
Spawn dev bot in development

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import {
 } from "firebase/storage";
 import { db, auth, storage } from "./firebase.js";
 import Sortable from "sortablejs";
+import { spawnDevBot } from './devBot';
 
 /* ───────────────────────────────── Mapbox ────────────────────────────────── */
 
@@ -215,6 +216,8 @@ export default function App() {
         lastActive: Date.now(),
         online: true,
       });
+
+      if (import.meta.env.VITE_DEV_BOT === '1') spawnDevBot();
 
     });
     return () => unsub();


### PR DESCRIPTION
## Summary
- spawn dev bot automatically after user login when `VITE_DEV_BOT` is set

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d516e2d483278ef671bccc900767