### PR TITLE
style: enhance bubble photo display

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -129,18 +129,26 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   background: rgba(0, 0, 0, 0.4);
   border-radius: 4px;
 }
-.bubble-photo {
-  flex: 0 0 100%;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  scroll-snap-align: center;
-  border: 4px solid #fff;
-  border-radius: 50%;
-  box-sizing: border-box;
-  background: #fff;
+.bubble-photo{
+  flex:0 0 100%;
+  width:100%;
+  height:100%;
+  object-fit:cover;             /* dříve bylo contain → proto nebyl kruh plný */
+  scroll-snap-align:center;
+  border-radius:50%;
+  box-sizing:border-box;
+
+  /* dvouvrstvý rámeček: bílý okraj + jemný prstýnek a stín */
+  border:4px solid #fff;
+  box-shadow:
+    0 0 0 4px rgba(255,255,255,.7),   /* prstýnek venku */
+    0 6px 16px rgba(0,0,0,.18);       /* měkký stín */
+  background:#fff;
 }
-.bubble-photo.empty { background: #f3f4f6; }
+.bubble-photo.empty{
+  background:#f3f4f6; border:4px dashed rgba(255,255,255,.8);
+  border-radius:50%;
+}
 .marker-wrapper.active img.bubble-photo {
   transform: translateY(10%);
 }


### PR DESCRIPTION
## Summary
- update bubble photo styles to use cover fit with double-layer ring and shadow
- style empty bubble photo with dashed border and neutral background

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68a4daa52e6c8327a5fde32e643dedd0