### PR TITLE
Use Poppins for bubble names

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PutPing</title>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -159,13 +159,15 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   align-items: center;
   padding: 4px 8px 12px;
 }
-.bubble-name {
-  margin-top: 12px;             /* níž pod fotkou */
-  font-size: 18px;
-  font-weight: 700;
-  color: #fff;                   /* bílý text */
-  text-shadow: 0 1px 2px rgba(0,0,0,.45); /* jemný stín pod ním */
-  text-align: center;
+.bubble-name{
+  margin-top:12px;
+  font-size:20px;           /* o chlup větší */
+  font-weight:700;
+  font-family:'Poppins', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color:#fff;
+  letter-spacing:.2px;
+  text-shadow:0 2px 6px rgba(0,0,0,.35);
+  text-align:center;
 }
 /* ukotveni tlacitka do spicky pinu */
 .bubble-actions{


### PR DESCRIPTION
## Summary
- load Google Fonts Poppins in index.html
- restyle `.bubble-name` with Poppins, larger size, and improved spacing

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f435dc108327821dda5d8fb38e04