### PR TITLE
feat: add inset outline to marker bubble

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -82,7 +82,9 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   height: 320px;
   background: #ff8fa1;
   clip-path: path('M120 0C186 0 240 54 240 120C240 220 120 320 120 320C120 320 0 220 0 120C0 54 54 0 120 0Z');
-  box-shadow: 0 2px 10px rgba(0,0,0,.15);
+  box-shadow:
+    inset 0 0 0 2px rgba(255,255,255,.9),   /* nový tenký rámeček */
+    0 2px 10px rgba(0,0,0,.15);             /* původní stín */
   text-align: center;
   font: 12px/1.45 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   z-index: 10;


### PR DESCRIPTION
## Summary
- add inset white outline to `.marker-bubble` and preserve existing drop shadow

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5f5a5586083279a6d40745ed78947