### PR TITLE
Add owner-specific dev bot flag

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -217,7 +217,7 @@ export default function App() {
         online: true,
       });
 
-      if (import.meta.env.VITE_DEV_BOT === '1') spawnDevBot();
+      if (import.meta.env.VITE_DEV_BOT === '1') spawnDevBot(uid);
 
     });
     return () => unsub();

--- a/src/devBot.js
+++ b/src/devBot.js
@@ -4,7 +4,7 @@ import { initSecondaryApp } from "./firebase.js";
 
 function pairIdOf(a,b){ return a<b ? `${a}_${b}` : `${b}_${a}`; }
 
-export async function spawnDevBot(){
+export async function spawnDevBot(ownerUid){
   const app = initSecondaryApp("dev-bot");
   const db2 = getDatabase(app);
   const auth2 = getAuth(app);
@@ -35,6 +35,8 @@ export async function spawnDevBot(){
     lat, lng,
     online: true,
     lastActive: Date.now(),
+    isDevBot: true,
+    privateTo: ownerUid,
   });
 
   // Reakce na pingy → spáruj pár a pošli zprávu


### PR DESCRIPTION
## Summary
- Extend `spawnDevBot` to accept an owner UID and mark bots as dev with `isDevBot` and `privateTo`
- Pass the signed-in user's UID when spawning a dev bot

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a5f8e765a883279d15198d00f648d8