### PR TITLE
Add guard to hide private dev bots

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -308,6 +308,16 @@ export default function App() {
 
       // aktualizace / přidání markerů
       Object.entries(data).forEach(([uid, u]) => {
+        // u = data daného uživatele, uid = jeho UID
+        if (u?.isDevBot && u?.privateTo && me && u.privateTo !== me.uid) {
+          // pokud jsme ho dřív vykreslili, zase ho odstraň
+          if (markers.current[uid]) {
+            markers.current[uid].remove();
+            delete markers.current[uid];
+          }
+          return; // pro ostatní klienty bota vůbec nerenderuj
+        }
+
         if (!Number.isFinite(u.lat) || !Number.isFinite(u.lng)) {
           if (markers.current[uid]) {
             if (openBubble.current === uid) openBubble.current = null;


### PR DESCRIPTION
## Summary
- Avoid rendering dev bot markers for clients other than the intended user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5fd90f2188327bc7264f7c73aa0b9