### PR TITLE
Handle dev bot visibility updates when private targets change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -382,6 +382,14 @@ export default function App() {
 
           markers.current[uid] = mk;
         } else {
+          if (u?.isDevBot && u?.privateTo && me && u.privateTo !== me.uid) {
+            // pokud jsme ho dřív vykreslili, zase ho odstraň
+            if (markers.current[uid]) {
+              markers.current[uid].remove();
+              delete markers.current[uid];
+            }
+            return; // pro ostatní klienty bota vůbec nerenderuj
+          }
           const shouldUpdate = isOnline || isMe;
           if (shouldUpdate) {
             markers.current[uid].setLngLat([u.lng, u.lat]);


### PR DESCRIPTION
## Summary
- hide existing dev bot markers when their `privateTo` field changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5feb61ec88327848506999c8cd416