### PR TITLE
feat: add auth bar overlay

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import {
 import { db, auth, storage } from "./firebase.js";
 import Sortable from "sortablejs";
 import { spawnDevBot } from './devBot';
+import { GoogleAuthProvider, signInWithRedirect, linkWithRedirect, getRedirectResult, signOut } from "firebase/auth";
 
 /* ───────────────────────────────── Mapbox ────────────────────────────────── */
 
@@ -962,6 +963,10 @@ export default function App() {
 
   return (
     <div>
+      <div className="auth-bar">
+        <button id="btnAuthPrimary"></button>
+        <button id="btnSignOut" title="Odhlásit se">Odhlásit</button>
+      </div>
       {isIOS && !locationConsent && (
         <div className="consent-modal">
           <div className="consent-modal__content">


### PR DESCRIPTION
## Summary
- add Firebase auth helper imports for redirect flows
- add authentication overlay bar with sign-in and sign-out buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a61725180883278752920978273294