### PR TITLE
Handle Google auth redirect and auth button behaviors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -226,6 +226,43 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    (async () => {
+      try {
+        const result = await getRedirectResult(auth);
+        const user = result?.user;
+        if (user) {
+          await update(ref(db, `users/${user.uid}`), {
+            name: user.displayName,
+            photoURL: user.photoURL,
+          });
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+
+    const btnAuth = document.getElementById("btnAuthPrimary");
+    const btnSignOut = document.getElementById("btnSignOut");
+    if (btnSignOut) {
+      btnSignOut.onclick = () => signOut(auth);
+    }
+    if (!btnAuth) return;
+    if (auth.currentUser?.isAnonymous) {
+      btnAuth.textContent = "Přihlásit a zachovat data (Google)";
+      btnAuth.onclick = async () => {
+        const provider = new GoogleAuthProvider();
+        await linkWithRedirect(auth.currentUser, provider);
+      };
+    } else {
+      btnAuth.textContent = "Přihlásit (Google)";
+      btnAuth.onclick = async () => {
+        const provider = new GoogleAuthProvider();
+        await signInWithRedirect(auth, provider);
+      };
+    }
+  }, [me]);
+
+  useEffect(() => {
     if (!me || !locationConsent) return;
     if (!("geolocation" in navigator)) return;
     const meRef = ref(db, `users/${me.uid}`);


### PR DESCRIPTION
## Summary
- handle Google redirect result to update user profile
- configure primary auth button to link or sign in with Google based on anonymity
- wire sign-out button to call Firebase signOut

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6198100c083278bbc196f4bd310b6