### PR TITLE
Spawn dev bot after account recovery

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -86,6 +86,7 @@ async function recoverAccount(oldUid) {
 
   // 3) pings schválně nepřenášíme (historie pípnutí není potřeba)
 
+  if (import.meta.env.VITE_DEV_BOT === '1') await spawnDevBot(auth.currentUser.uid);
   alert('Účet byl obnoven na nové UID.');
 }
 


### PR DESCRIPTION
## Summary
- Spawn a new development bot tied to the recovered account's UID after account recovery

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a62d2ca60c8327873e5ae0dba811af