### PR TITLE
feat: handle location permission button with Permissions API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -282,6 +282,41 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    const btn = document.getElementById("btnEnableLoc");
+    if (!btn) return;
+
+    const show = (v) => (btn.style.display = v ? "inline-flex" : "none");
+
+    const wire = () => {
+      btn.onclick = () => {
+        // uživatelský gesture → vyžádej polohu
+        if (navigator.geolocation?.getCurrentPosition) {
+          navigator.geolocation.getCurrentPosition(() => {}, () => {});
+        }
+        // tvá existující logika
+        if (typeof acceptLocation === "function") acceptLocation();
+      };
+    };
+
+    if ("permissions" in navigator && navigator.permissions.query) {
+      navigator.permissions
+        .query({ name: "geolocation" })
+        .then((status) => {
+          show(status.state !== "granted");
+          status.onchange = () => show(status.state !== "granted");
+          wire();
+        })
+        .catch(() => {
+          show(true);
+          wire();
+        });
+    } else {
+      show(true);
+      wire();
+    }
+  }, []);
+
+  useEffect(() => {
     (async () => {
       try {
         const result = await getRedirectResult(auth);


### PR DESCRIPTION
## Summary
- show or hide location enable button based on geolocation permission
- trigger location request and existing accept handler on click

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6a8766fac8327b598f37af4b7c52c