### PR TITLE
Handle user disconnect presence update

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import {
   push,
   serverTimestamp,
   get,
+  onDisconnect,
 } from "firebase/database";
 import {
   ref as sref,
@@ -267,7 +268,13 @@ export default function App() {
       const photoURL = u.photoURL || null;
       setMe({ uid: u.uid, name });
 
-      await update(ref(db, `users/${u.uid}`), {
+      const myRef = ref(db, `users/${u.uid}`);
+      onDisconnect(myRef).update({ online: false, lastActive: serverTimestamp() });
+      window.addEventListener("beforeunload", () => {
+        update(myRef, { online: false, lastActive: Date.now() });
+      });
+
+      await update(myRef, {
         name,
         photoURL,
         lastActive: Date.now(),


### PR DESCRIPTION
## Summary
- Ensure user is marked offline on disconnect using Firebase `onDisconnect`
- Record last active time on browser unload

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ab8e8bcc8327b8de0b55211d8e53