### PR TITLE
Reduce online presence TTL to 10 minutes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,7 @@ import { GoogleAuthProvider, signInWithRedirect, linkWithRedirect, getRedirectRe
 
 mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
 
-const ONLINE_TTL_MS = 30 * 60_000;  // 30 minut (můžeš snížit později)
+const ONLINE_TTL_MS = 10 * 60_000; // 10 minut
 
 /* ───────────────────────────── Pomocné funkce ───────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Define `ONLINE_TTL_MS` as 10 minutes to govern user presence
- Use this TTL when calculating `isOnline` during marker updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac7f37988327823f0e3595e48a75