### PR TITLE
Hide deprecated floating buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -560,3 +560,8 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 /* schovej starou lištu, pokud ještě existuje */
 .auth-bar{ display:none !important; }
 
+
+/* schovej staré plovoucí + a minikolečko, kdyby ještě někde vznikly */
+#btnPlus, .map-plus, .action-fab, .floating-plus, .mini-gear, #miniGear {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- Hide legacy floating plus and mini gear button in CSS

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1b50a6483279f497118f97a324b