### PR TITLE
feat: reposition Mapbox zoom controls above FAB

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -557,6 +557,13 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 .gear-menu button:hover{ filter:brightness(.97); }
 
+/* Mapbox / MapLibre zoom ovladače posunout nad FAB (podporujeme oboje prefixed) */
+.mapboxgl-ctrl-bottom-right,
+.maplibregl-ctrl-bottom-right {
+  bottom: calc(88px + env(safe-area-inset-bottom)) !important;
+  right:  calc(12px + env(safe-area-inset-right)) !important;
+}
+
 /* schovej starou lištu, pokud ještě existuje */
 .auth-bar{ display:none !important; }
 


### PR DESCRIPTION
## Summary
- ensure Mapbox and MapLibre zoom controls are offset to clear the floating action button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e288867483279824692822c7e12e