### PR TITLE
Add zoom controls and location option to gear menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -313,31 +313,18 @@ export default function App() {
     if (!enable) return;
 
     const show = (v) => (enable.style.display = v ? 'inline-flex' : 'none');
-
-    const wire = () => {
-      enable.onclick = () => {
-        if (navigator.geolocation?.getCurrentPosition)
-          navigator.geolocation.getCurrentPosition(() => {}, () => {});
-        if (typeof acceptLocation === 'function') acceptLocation();
-        setOpen(false);
-      };
-    };
-
     if ('permissions' in navigator && navigator.permissions.query) {
       navigator.permissions
         .query({ name: 'geolocation' })
         .then((status) => {
           show(status.state !== 'granted');
           status.onchange = () => show(status.state !== 'granted');
-          wire();
         })
         .catch(() => {
           show(true);
-          wire();
         });
     } else {
       show(true);
-      wire();
     }
   }, []);
 
@@ -390,6 +377,15 @@ export default function App() {
       await signOut(auth);
       setOpen(false);
     };
+
+    document.getElementById('btnEnableLoc')?.addEventListener('click', () => {
+      if (navigator.geolocation?.getCurrentPosition)
+        navigator.geolocation.getCurrentPosition(() => {}, () => {});
+      if (typeof acceptLocation === 'function') acceptLocation();
+    });
+
+    document.getElementById('btnZoomIn')?.addEventListener('click', () => map.zoomIn());
+    document.getElementById('btnZoomOut')?.addEventListener('click', () => map.zoomOut());
 
     // změna po auth redirectu
     getRedirectResult(auth).finally(refreshPrimary);
@@ -1267,6 +1263,8 @@ export default function App() {
         <button id="btnRecover" role="menuitem">Obnovit účet</button>
         <button id="btnSignOut" role="menuitem">Odhlásit</button>
         <button id="btnEnableLoc" role="menuitem">Povolit polohu</button>
+        <button id="btnZoomIn" role="menuitem">Přiblížit mapu</button>
+        <button id="btnZoomOut" role="menuitem">Oddálit mapu</button>
       </div>
 
       {showChatList && (


### PR DESCRIPTION
## Summary
- Integrate enable location, zoom in, and zoom out actions into gear menu
- Wire up gear menu buttons to geolocation and map zoom functions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e3b382b08327b606b19124d3c8e4