### PR TITLE
Add gallery, chat and settings options to gear menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -211,6 +211,21 @@ export default function App() {
     }
   }
 
+  function openGalleryModal() {
+    setShowGallery(true);
+    setOpen(false);
+  }
+
+  function openChatsModal() {
+    setShowChatList(true);
+    setOpen(false);
+  }
+
+  function openSettingsModal() {
+    setShowSettings(true);
+    setOpen(false);
+  }
+
   // toggle gear menu
   useEffect(() => {
     const btn = document.getElementById('btnGear');
@@ -386,6 +401,10 @@ export default function App() {
 
     document.getElementById('btnZoomIn')?.addEventListener('click', () => map.zoomIn());
     document.getElementById('btnZoomOut')?.addEventListener('click', () => map.zoomOut());
+
+    document.getElementById('btnGallery')?.addEventListener('click', openGalleryModal);
+    document.getElementById('btnChats')?.addEventListener('click', openChatsModal);
+    document.getElementById('btnSettings')?.addEventListener('click', openSettingsModal);
 
     // změna po auth redirectu
     getRedirectResult(auth).finally(refreshPrimary);
@@ -1262,6 +1281,10 @@ export default function App() {
         <button id="btnAuthPrimary" role="menuitem"></button>
         <button id="btnRecover" role="menuitem">Obnovit účet</button>
         <button id="btnSignOut" role="menuitem">Odhlásit</button>
+        <hr className="gear-sep" />
+        <button id="btnGallery" role="menuitem">Galerie fotek</button>
+        <button id="btnChats" role="menuitem">Chaty</button>
+        <button id="btnSettings" role="menuitem">Nastavení</button>
         <button id="btnEnableLoc" role="menuitem">Povolit polohu</button>
         <button id="btnZoomIn" role="menuitem">Přiblížit mapu</button>
         <button id="btnZoomOut" role="menuitem">Oddálit mapu</button>


### PR DESCRIPTION
## Summary
- expand gear menu with links to Gallery, Chats, and Settings plus separator
- wire up click handlers to open respective modals
- include helper functions to open each modal and close gear menu

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6eb70ca4883278f568f7520e8031d