### PR TITLE
Add bottom sheet gallery styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -557,6 +557,27 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 .gear-menu button:hover{ filter:brightness(.97); }
 
+/* Bottom sheet gallery */
+.sheet{
+  position:fixed; left:0; right:0; bottom:0;
+  transform:translateY(100%); transition:transform .2s ease;
+  background:#fff; border-radius:16px 16px 0 0;
+  box-shadow:0 -12px 30px rgba(0,0,0,.25); z-index:1001;
+  max-height:70vh; padding:12px;
+}
+.sheet.open{ transform:translateY(0); }
+.sheet-head{ display:flex; align-items:center; gap:8px; }
+.sheet-head h3{ flex:1; margin:0; }
+.sheet-head #btnAddPhoto{ background:#111; color:#fff; border:none; border-radius:10px; padding:8px 12px; font-weight:700; }
+.sheet-head #btnCloseGallery{ background:transparent; border:none; font-size:20px; padding:6px 10px; }
+
+.grid{ margin-top:10px; display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }
+.tile{ position:relative; border-radius:12px; overflow:hidden; background:#f3f4f6; }
+.tile img{ width:100%; height:100%; object-fit:cover; display:block; }
+.tile .del{ position:absolute; top:6px; right:6px; background:rgba(0,0,0,.65); color:#fff; border:none; border-radius:50%; width:28px;height:28px; }
+.tile .grab{ position:absolute; bottom:6px; right:6px; background:rgba(0,0,0,.5); color:#fff; border-radius:6px; padding:2px 6px; font-weight:700; font-family:monospace; }
+.gear-sep{ border:none; border-top:1px solid rgba(0,0,0,.1); margin:8px 0; }
+
 /* Mapbox / MapLibre zoom ovladače posunout nad FAB (podporujeme oboje prefixed) */
 .mapboxgl-ctrl-bottom-right,
 .maplibregl-ctrl-bottom-right {


### PR DESCRIPTION
## Summary
- style new bottom sheet gallery with fixed position, transitions, and head controls
- define grid and tile styles for gallery images and add gear-sep separator

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ef44c4e48327854665709a343aed