### PR TITLE
Add chats modal and listing logic

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -593,3 +593,9 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 #btnPlus, .map-plus, .action-fab, .floating-plus, .mini-gear, #miniGear {
   display: none !important;
 }
+
+.chat-row{ width:100%; display:flex; gap:10px; align-items:center; padding:10px; border-radius:12px; background:#f9fafb; border:none; text-align:left; }
+.chat-row + .chat-row{ margin-top:8px; }
+.chat-row .avatar{ width:44px; height:44px; border-radius:50%; object-fit:cover; background:#eee; }
+.chat-row .name{ font-weight:700; }
+.chat-row .sub{ font-size:12px; color:#6b7280; }


### PR DESCRIPTION
## Summary
- add chats modal markup and styles
- populate chat list from Firebase and wire map centering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6f0c5444c8327a14e8c7bdd920090