### PR TITLE
Add chat panel layout and styles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1294,6 +1294,29 @@ export default function App() {
       {/* Mapa */}
       <div id="map" style={{ width: "100vw", height: "100vh" }} />
 
+      <div id="chatPanel" className="chat-panel hidden" aria-hidden="true">
+        <div className="chat-header">
+          <button id="btnCloseChat" title="Zpět">←</button>
+          <div className="chat-title"></div>
+          <button id="btnCancelChat" className="danger">Zrušit chat</button>
+        </div>
+        <div
+          id="chatMessages"
+          className="chat-messages"
+          role="log"
+          aria-live="polite"
+        ></div>
+        <form id="chatForm" className="chat-form">
+          <input
+            id="chatInput"
+            type="text"
+            placeholder="Napiš zprávu…"
+            autocomplete="off"
+          />
+          <button id="chatSend" type="submit">Odeslat</button>
+        </form>
+      </div>
+
       <div id="galleryModal" className="sheet" aria-hidden="true">
         <div className="sheet-head">
           <h3>Moje fotky</h3>

--- a/src/index.css
+++ b/src/index.css
@@ -600,3 +600,31 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 
 .switch{ display:flex; align-items:center; gap:10px; padding:10px; background:#f3f4f6; border-radius:12px; }
 .switch input{ width:18px; height:18px; }
+
+.chat-panel{
+  position:fixed; inset:0;
+  background: rgba(255,255,255,.9);
+  backdrop-filter: blur(8px);
+  display:flex; flex-direction:column;
+  z-index:1200;
+}
+.chat-panel.hidden{ display:none; }
+
+.chat-header{
+  display:flex; align-items:center; justify-content:space-between;
+  gap:8px; padding:10px 12px;
+  padding-top: calc(10px + env(safe-area-inset-top));
+  border-bottom:1px solid rgba(0,0,0,.08);
+  background:#fff;
+}
+.chat-header .danger{ background:#ef4444; color:#fff; border:none; padding:8px 12px; border-radius:10px; }
+.chat-title{ font-weight:700; }
+
+.chat-messages{ flex:1; overflow:auto; padding:12px; }
+.chat-form{
+  display:flex; gap:8px; padding:10px 12px;
+  padding-bottom: calc(10px + env(safe-area-inset-bottom));
+  background:#fff; border-top:1px solid rgba(0,0,0,.08);
+}
+#chatInput{ flex:1; border:1px solid #ddd; border-radius:12px; padding:10px 12px; }
+#chatSend{ border:none; border-radius:12px; padding:10px 14px; font-weight:600; background:#111; color:#fff; }


### PR DESCRIPTION
## Summary
- add chat panel HTML right after the map
- style new chat panel in index.css

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6fbc0a828832781a5c00b2a8ca544