### PR TITLE
Raise z-index for gear menu and chat panel

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -540,7 +540,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   opacity: 0;
   pointer-events: none;
   transition: transform .18s ease, opacity .18s ease;
-  z-index: 1000;
+  z-index: 1100;
 }
 .gear-menu.open{ transform:translateY(0); opacity:1; pointer-events:auto; }
 
@@ -606,7 +606,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   background: rgba(255,255,255,.9);
   backdrop-filter: blur(8px);
   display:flex; flex-direction:column;
-  z-index:1200;
+  z-index:1200; /* nad menu */
 }
 .chat-panel.hidden{ display:none; }
 


### PR DESCRIPTION
## Summary
- elevate gear menu overlay above other elements
- ensure chat panel sits above gear menu with comment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7058eb3788327872f476ef184d7c8