### PR TITLE
Fix filtering of chat pairs for history list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -224,7 +224,10 @@ export default function App() {
     const pairsSnap = await get(ref(db, 'pairs'));
     const pairs = pairsSnap.val() || {};
     const my = auth.currentUser?.uid;
-    const myPairs = Object.keys(pairs).filter(pid => pid.includes(my));
+    const myPairs = Object.keys(pairs).filter((pid) => {
+      const [a, b] = pid.split('_');
+      return a === my || b === my;
+    });
     if (!myPairs.length){ box.innerHTML = '<p>Žádné konverzace</p>'; return; }
 
     const usersSnap = await get(ref(db, 'users'));


### PR DESCRIPTION
## Summary
- Correctly identify user's chat pairs when building chat history

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a72f3e711883279036ab720ffe3651