### PR TITLE
Fix auth menu buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1241,11 +1241,6 @@ export default function App() {
 
   return (
     <div>
-      <div className="auth-bar">
-        <button id="btnAuthPrimary"></button>
-        <button id="btnRecover">Obnovit účet</button>
-        <button id="btnSignOut" title="Odhlásit se">Odhlásit</button>
-      </div>
       {isIOS && !locationConsent && (
         <div className="consent-modal">
           <div className="consent-modal__content">

--- a/src/index.css
+++ b/src/index.css
@@ -478,30 +478,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   transform: translateX(-50%);
 }
 
-/* Auth bar */
-.auth-bar{
-  position: fixed;
-  left: 50%;
-  bottom: calc(12px + env(safe-area-inset-bottom)); /* iOS safe-area */
-  transform: translateX(-50%);
-  display: flex; gap: 8px;
-  z-index: 1000;
-  background: rgba(255,255,255,.9);
-  backdrop-filter: blur(6px);
-  padding: 6px 10px;
-  border-radius: 999px;
-  box-shadow: 0 4px 14px rgba(0,0,0,.12);
-}
-
-/* fallback pro prohlížeče bez env() */
-@supports not (bottom: calc(12px + env(safe-area-inset-bottom))) {
-  .auth-bar{ bottom: 12px; }
-}
-
-.auth-bar button{
-  border: none; border-radius: 999px;
-  padding: 8px 14px; font-weight: 600; cursor: pointer;
-}
+/* Auth buttons */
 #btnAuthPrimary{ background: #111; color:#fff; }
 #btnSignOut{ background: #eee; }
 
@@ -562,8 +539,6 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 .gear-menu button:hover{ filter:brightness(.97); }
 
-/* pro jistotu: starou auth lištu trvale schovej */
-.auth-bar{ display:none !important; }
 
 /* Bottom sheet gallery */
 .sheet{


### PR DESCRIPTION
## Summary
- remove obsolete hidden auth bar so Google login, account recovery, and sign-out handlers attach to visible menu
- clean up unused auth bar CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76436bd088327bc4c09d936d84b15