### PR TITLE
Fix chat modal open/close actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -238,6 +238,7 @@ export default function App() {
   }
 
   function openChatsModal(){ buildChats(); openSheet('chatsModal'); }
+  function closeChatsModal(){ closeSheet('chatsModal'); }
 
   async function buildChats(){
     const box = document.getElementById('chatsList'); if(!box) return;
@@ -272,9 +273,15 @@ export default function App() {
     });
     document.querySelectorAll('.conv-item').forEach(el => {
       const peer = el.getAttribute('data-uid');
-      el.onclick = () => openChat(peer);
+      el.onclick = () => { openChat(peer); closeChatsModal(); };
     });
   }
+
+  useEffect(() => {
+    const btnClose = document.getElementById('btnCloseChats');
+    btnClose?.addEventListener('click', closeChatsModal);
+    return () => btnClose?.removeEventListener('click', closeChatsModal);
+  }, []);
 
   function openSettingsModal(){
     const chk = document.getElementById('chkSound');


### PR DESCRIPTION
## Summary
- Allow closing chat list with a dedicated close function
- Close chat list when starting a chat from the list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a768ec1f1c832784da55ec8da1fe55