### PR TITLE
Only close chat list when conversation opens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -273,7 +273,7 @@ export default function App() {
     });
     document.querySelectorAll('.conv-item').forEach(el => {
       const peer = el.getAttribute('data-uid');
-      el.onclick = () => { openChat(peer); closeChatsModal(); };
+      el.onclick = () => { if (openChat(peer)) closeChatsModal(); };
     });
   }
 
@@ -1128,12 +1128,12 @@ export default function App() {
   }, [chatMsgs, openChatWith]);
 
   function openChat(uid) {
-    if (!me) return;
+    if (!me) return false;
     const pid = getPairId(me.uid, uid);
     const pair = pairPings[pid] || {};
     if (!((pair[me.uid] && pair[uid]) || chatPairs[pid])) {
       alert("Chat je dostupný až po vzájemném pingnutí.");
-      return;
+      return false;
     }
     setOpenChatWith(uid);
     setMarkerHighlights((prev) => {
@@ -1141,6 +1141,7 @@ export default function App() {
       delete copy[uid];
       return copy;
     });
+    return true;
   }
 
   function closeChat() {
@@ -1455,8 +1456,7 @@ export default function App() {
                   key={pid}
                   className="chat-list__item"
                   onClick={() => {
-                    openChat(otherUid);
-                    setShowChatList(false);
+                    if (openChat(otherUid)) setShowChatList(false);
                   }}
                 >
                   {u?.name || "Neznámý uživatel"}


### PR DESCRIPTION
## Summary
- Return a boolean from `openChat` to signal when a chat is opened successfully
- Close chat list modals only if `openChat` succeeds

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76af6b3788327aa22e86df1c3a6fd