### PR TITLE
Fix missing photos in gallery after restart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -595,6 +595,12 @@ export default function App() {
     const usersRef = ref(db, "users");
     const unsub = onValue(usersRef, (snap) => {
       const data = snap.val() || {};
+      // Firebase RTDB may return arrays as objects; ensure photos are arrays
+      Object.values(data).forEach((u) => {
+        if (u && u.photos && !Array.isArray(u.photos)) {
+          u.photos = Object.values(u.photos);
+        }
+      });
       setUsers(data);
 
       // aktualizace / přidání markerů


### PR DESCRIPTION
## Summary
- Ensure Firebase user photos are normalized to arrays when loaded so galleries render correctly after reopening the app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76f2a8b8883278935a278bb1d3bf8