### PR TITLE
fix(chat): overlay above map

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1483,6 +1483,7 @@ export default function App() {
         <div
           style={{
             position: "fixed",
+            inset: 0,
             right: "calc(12px + env(safe-area-inset-right))",
             bottom: "calc(12px + env(safe-area-inset-bottom))",
             width: "min(92vw, 360px)",


### PR DESCRIPTION
## Summary
- ensure chat panel overlay covers full viewport with fixed positioning

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7fdd4b34083278e508543c48f34b5