### PR TITLE
fix(gallery): open overlay from FAB

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -386,7 +386,7 @@ export default function App() {
 
     btnRecover  && (btnRecover.onclick  = withClose(async () => { const o = prompt('Vlož staré UID:'); if (o) await recoverAccount(o); }));
     btnSignOut  && (btnSignOut.onclick  = withClose(async () => { await signOut(auth); }));
-    btnGallery  && (btnGallery.onclick  = withClose(() => openGalleryModal()));
+    btnGallery  && (btnGallery.onclick  = withClose(() => setShowGallery(true)));
     btnChats    && (btnChats.onclick    = withClose(() => openChatsModal()));
     btnSettings && (btnSettings.onclick = withClose(() => openSettingsModal()));
     btnEnable   && (btnEnable.onclick   = withClose(() => {


### PR DESCRIPTION
## Summary
- wire gallery FAB to open overlay via setShowGallery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7feb077988327a1c5be26c21f7ccc