### PR TITLE
fix(gallery): overlay above map

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1615,13 +1615,13 @@ export default function App() {
         <div
           onClick={() => setShowGallery(false)}
           style={{
-            position: "absolute",
+            position: "fixed",
             inset: 0,
             background: "rgba(0,0,0,.25)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            zIndex: 30,
+            zIndex: 2400,
           }}
         >
           <div


### PR DESCRIPTION
## Summary
- use fixed positioning for gallery modal overlay and increase z-index so it shows above map

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7ffd69f18832785b91f8732c85587