### PR TITLE
style: ensure chat overlay sits above map

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -627,3 +627,10 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   background:#111 !important;
   color:#fff !important;
 }
+
+#chatOverlay{
+  position: fixed !important;
+  inset: 0 !important;
+  z-index: 2400 !important;
+  pointer-events: auto !important;
+}


### PR DESCRIPTION
## Summary
- keep chat overlay fixed and clickable atop the map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8312ed3488327998818d9aa38bdd9