### PR TITLE
Add row class and data UID to chat rows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -257,8 +257,8 @@ export default function App() {
     myPairs.forEach(pid => {
       const [a,b] = pid.split('_'); const uid = a===my ? b : a;
       const u = users[uid] || { name:'Neznámý uživatel' };
-      const row = document.createElement('button');
-      row.className = 'chat-row conv-item';
+      const row = document.createElement('div');
+      row.className = 'row chat-row';
       row.setAttribute('data-uid', uid);
       row.innerHTML = `
       <img class="avatar" src="${(u.photos&&u.photos[0])||u.photoURL||''}" alt="">


### PR DESCRIPTION
## Summary
- render chat rows as divs with `row chat-row` classes and `data-uid` attribute

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a836ba49888327bdf4a35f05f1a777