### PR TITLE
fix(settings): prefill reads by currentUser uid

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -392,7 +392,8 @@ export default function App() {
     form?.addEventListener('submit', handleSave);
     btnSav?.addEventListener('click', handleSave);
 
-    const u = users?.[me?.uid] || {};
+    const myUid = auth.currentUser?.uid || me?.uid || null;
+    const u = (myUid && users?.[myUid]) ? users[myUid] : {};
     const prefs = u.pingPrefs || {gender:'any', minAge:16, maxAge:100};
     if(form){
       form.querySelector('#sName').value = u.name || '';


### PR DESCRIPTION
## Summary
- use authenticated uid to prefill user settings

## Testing
- `npm test` *(fails: Missing script "test"  )*


------
https://chatgpt.com/codex/tasks/task_e_68a873e61d8083278557dd892138e95b