### PR TITLE
feat/marker-gender-ring-v2

### DIFF
--- a/src/devBot.js
+++ b/src/devBot.js
@@ -32,6 +32,7 @@ export async function spawnDevBot(ownerUid){
     name: "Kontrolní bot",
     photoURL: "https://i.pravatar.cc/200?img=12",
     photos: [],
+    gender: "muz",
     lat, lng,
     online: true,
     lastActive: Date.now(),


### PR DESCRIPTION
## Summary
- add gender ring helper (men=pink, women=blue, other=green)
- show ring via box-shadow and keep pulse only for highlights
- pass gender ring when creating/updating markers
- set dev bot gender for testing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8a476f3208327a82d89a9e8c763dc