### PR TITLE
Use gender ring when updating marker avatar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1203,7 +1203,7 @@ export default function App() {
       const avatarEl = markers.current[uid]?.getElement()?.querySelector('.marker-avatar');
       if (avatarEl) {
         const picked = list[idx] || photoURL;
-        setMarkerAppearance(avatarEl, picked, avatarEl.style.backgroundColor || "#147af3");
+        setMarkerAppearance(avatarEl, picked, avatarEl.style.backgroundColor || '#147af3', false, getGenderRing(users[uid]));
       }
     };
 


### PR DESCRIPTION
## Summary
- Pass gender ring to `setMarkerAppearance` within `getBubbleContent`'s `commitIndex`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8be973da48327a8a31800136f88de