### PR TITLE
feat: pass ring color to marker bubble

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1154,6 +1154,7 @@ export default function App() {
 
     const bubble = document.createElement("div");
     bubble.className = "marker-bubble";
+    bubble.style.setProperty('--ring-color', getGenderRing(users[uid]) || 'transparent');
     bubble.addEventListener("click", (e) => e.stopPropagation());
     (function applyBubbleRing(){
       const ring = getGenderRing(users[uid]);


### PR DESCRIPTION
## Summary
- expose gender ring color to marker bubble via CSS variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a95d4a4d9c8327b398df1c1b747705