### PR TITLE
style(onboarding): bottom-sheet under splash; colors tuned to dusty-pink

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,12 @@
 html, body, #root { height: 100%; }
 body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color: #111827; }
 
+:root{
+  --pp-pink: #f4a7bd;      /* starorůžová */
+  --pp-plum: #7a2845;      /* tmavší kontrast */
+  --pp-cream: #fff7fa;     /* velmi světlá růžová */
+}
+
 /* Map container */
 .map { width: 100vw; height: 100vh; }
 
@@ -17,7 +23,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   z-index: 1000;
   transition: opacity 0.5s ease;
   padding: 7mm;
-  background: #ff8fa1;
+  background: transparent !important;
 }
 .intro-screen--hidden {
   opacity: 0;
@@ -747,11 +753,27 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   pointer-events: none;
 }
 
-.onboard{position:fixed;inset:0;background:#f472b6;display:flex;align-items:center;justify-content:center;z-index:3000}
-.onboard-card{background:#fff;border-radius:18px;box-shadow:0 10px 30px rgba(0,0,0,.15);width:min(92vw,420px);padding:20px}
+.onboard{
+  position:fixed; inset:0; z-index:3000;
+  /* jemný přechod od transparentní k tmavému, aby byl text čitelný */
+  background: linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(0,0,0,.25) 100%);
+  display:flex; align-items:flex-end; justify-content:center;
+  padding:16px;
+}
+.onboard-card{
+  width: min(96vw, 520px);
+  background: rgba(255,255,255,.96);
+  border-radius: 18px 18px 0 0;
+  box-shadow: 0 10px 30px rgba(0,0,0,.15);
+  padding: 20px;
+}
 .onboard h1{margin:0 0 8px;font-size:24px;text-align:center}
 .onboard .btn{display:block;width:100%;padding:12px 14px;border-radius:12px;border:0;margin-top:12px;font-weight:700;cursor:pointer}
-.btn-dark{background:#111;color:#fff}
-.btn-light{background:#f3f4f6}
+.btn-dark{ background: var(--pp-plum); color:#fff; }
+.btn-light{
+  background: var(--pp-cream);
+  color: var(--pp-plum);
+  border: 1px solid rgba(122,40,69,.2);
+}
 .row{display:flex;gap:8px}
 .row .btn{flex:1}


### PR DESCRIPTION
## Summary
- Add dusty-pink color palette variables
- Make splash screen transparent
- Restyle onboarding to bottom sheet with palette-matched buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a96e567e3c832797b3adb24405de05