### PR TITLE
fix/onboarding-full-and-instant-gender

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -191,6 +191,13 @@ export default function App() {
     localStorage.setItem('pp_onboard_v1', '1');
     setStep(0);
   };
+  useEffect(() => {
+    if (step === 0 && showIntro) {
+      setFadeIntro(true);
+      const t = setTimeout(() => setShowIntro(false), 500);
+      return () => clearTimeout(t);
+    }
+  }, [step, showIntro]);
   const [markerHighlights, setMarkerHighlights] = useState({}); // uid -> color
   const [locationConsent, setLocationConsent] = useState(() =>
     localStorage.getItem("locationConsent") === "1"
@@ -2135,13 +2142,8 @@ export default function App() {
       {showIntro && (
         <div
           className={`intro-screen ${fadeIntro ? "intro-screen--hidden" : ""}`}
-          onClick={() => {
-            setFadeIntro(true);
-            setTimeout(() => setShowIntro(false), 500);
-          }}
-        >
-          <img src="/splash.jpg" alt="PutPing" className="intro-screen__img" />
-        </div>
+          style={{ backgroundImage: "url(/splash.jpg)" }}
+        />
       )}
 
       {step>0 && (
@@ -2174,9 +2176,21 @@ export default function App() {
                   <input placeholder="Jméno" value={me?.name||''}
                     onChange={e=>{ const name=e.target.value; setMe(m=>({...m,name})); saveProfileDebounced(me?.uid,{name}); }}/>
                   <div className="row">
-                    <button className="btn btn-light" onClick={()=>{ setMe(m=>({...m,gender:'muz'})); saveProfileDebounced(me?.uid,{gender:'muz'}); }}>Muž</button>
-                    <button className="btn btn-light" onClick={()=>{ setMe(m=>({...m,gender:'žena'})); saveProfileDebounced(me?.uid,{gender:'žena'}); }}>Žena</button>
-                    <button className="btn btn-light" onClick={()=>{ setMe(m=>({...m,gender:'jine'})); saveProfileDebounced(me?.uid,{gender:'jine'}); }}>Jiné</button>
+                    <button
+                      type="button"
+                      className={`pill${me?.gender==='muz'?" active":""}`}
+                      onClick={()=>{ const gender='muz'; setMe(m=>({...m,gender})); saveProfileDebounced(me?.uid,{gender}); }}
+                    >Muž</button>
+                    <button
+                      type="button"
+                      className={`pill${me?.gender==='žena'?" active":""}`}
+                      onClick={()=>{ const gender='žena'; setMe(m=>({...m,gender})); saveProfileDebounced(me?.uid,{gender}); }}
+                    >Žena</button>
+                    <button
+                      type="button"
+                      className={`pill${me?.gender==='jine'?" active":""}`}
+                      onClick={()=>{ const gender='jine'; setMe(m=>({...m,gender})); saveProfileDebounced(me?.uid,{gender}); }}
+                    >Jiné</button>
                   </div>
                   <input type="number" placeholder="Věk (volitelné)" value={me?.age||''}
                     onChange={e=>{ const age=Number(e.target.value)||null; setMe(m=>({...m,age})); saveProfileDebounced(me?.uid,{age}); }}/>

--- a/src/index.css
+++ b/src/index.css
@@ -14,25 +14,18 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 .map { width: 100vw; height: 100vh; }
 
 /* Intro splash */
-.intro-screen {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
+.intro-screen{
+  position: fixed !important;
+  inset: 0 !important;
+  width: 100vw; height: 100vh;
+  display: flex; align-items: center; justify-content: center;
+  background-size: cover; background-position: center;
+  z-index: 2700;
+  pointer-events: none;
   transition: opacity 0.5s ease;
-  padding: 7mm;
-  background: transparent !important;
+  padding: 0;
 }
-.intro-screen--hidden {
-  opacity: 0;
-}
-.intro-screen__img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
+.intro-screen--hidden { opacity: 0; }
 
 /* Location consent modal */
 .consent-modal {
@@ -753,12 +746,18 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   pointer-events: none;
 }
 
+/* Onboarding = bottom sheet laděný do starorůžové */
+:root{
+  --pp-pink: #f4a7bd;
+  --pp-plum: #7a2845;
+  --pp-cream: #fff7fa;
+}
+
 .onboard{
-  position:fixed; inset:0; z-index:3000;
-  /* jemný přechod od transparentní k tmavému, aby byl text čitelný */
-  background: linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(0,0,0,.25) 100%);
-  display:flex; align-items:flex-end; justify-content:center;
-  padding:16px;
+  position: fixed; inset: 0; z-index: 2800;
+  display: flex; align-items: flex-end; justify-content: center;
+  background: linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(0,0,0,.24) 100%);
+  padding: 16px;
 }
 .onboard-card{
   width: min(96vw, 520px);
@@ -767,13 +766,13 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   box-shadow: 0 10px 30px rgba(0,0,0,.15);
   padding: 20px;
 }
-.onboard h1{margin:0 0 8px;font-size:24px;text-align:center}
-.onboard .btn{display:block;width:100%;padding:12px 14px;border-radius:12px;border:0;margin-top:12px;font-weight:700;cursor:pointer}
+
+/* Tlačítka a výběr pohlaví (pill + aktivní rámeček) */
+.btn{ display:block; width:100%; padding:12px 14px; border-radius:12px; border:0; font-weight:700; cursor:pointer; }
 .btn-dark{ background: var(--pp-plum); color:#fff; }
-.btn-light{
-  background: var(--pp-cream);
-  color: var(--pp-plum);
-  border: 1px solid rgba(122,40,69,.2);
-}
-.row{display:flex;gap:8px}
-.row .btn{flex:1}
+.btn-light{ background: var(--pp-cream); color: var(--pp-plum); border:1px solid rgba(122,40,69,.2); }
+.row{ display:flex; gap:8px; }
+.row .btn{ flex:1; }
+
+.pill{ padding:10px 12px; border-radius:12px; border:1px solid rgba(122,40,69,.25); cursor:pointer; background:#fff; }
+.pill.active{ box-shadow: 0 0 0 2px #fff, 0 0 0 4px #EC4899; border-color: transparent; } /* MUŽ = růžový obdélník */


### PR DESCRIPTION
## Summary
- ensure intro splash covers the entire viewport without blocking onboarding
- restyle onboarding as dusty pink bottom sheet with gender pill selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9899815e08327b54ba8fce2cecc75