### PR TITLE
Fix onboarding step initialization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -188,7 +188,8 @@ export default function App() {
   };
 
   // Pozn.: inicializuj rovnou konkrétním krokem (žádný -1 problik)
-  const [step, setStep] = useState(getOnboardStep);
+  // Funkci zavolej hned, aby se neuložila do stavu samotná reference
+  const [step, setStep] = useState(getOnboardStep());
 
   useEffect(() => {
     // přepočítej hned po mountu


### PR DESCRIPTION
## Summary
- Ensure onboarding step is initialized by invoking `getOnboardStep()` immediately
- Prevent intro screen (terms, login, settings) from being skipped

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a9e0595d8c8327beab012651558ca7