### PR TITLE
fix(intro): keep splash visible for wizard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -226,16 +226,15 @@ export default function App() {
     setStep(computeStep(me));
   }, [me]);  // ⬅ jakmile dorazí me z DB/cache, krok se srovná
 
-  // 4) Když jsme ve „staré“ cestě (step === 0), nech intro chvilku a fade-out
+  // 4) Neschovávej intro při step > 0 (zůstane jako pozadí wizardu)
   useEffect(() => {
     if (step === 0 && introState === 'show') {
+      // starý uživatel: krátký fade do mapy
       setIntroState('fade');
-      const t = setTimeout(() => setIntroState('hide'), 700);
+      const t = setTimeout(() => setIntroState('hide'), 800);
       return () => clearTimeout(t);
     }
-    if (step > 0 && introState === 'show') {
-      setIntroState('hide');
-    }
+    // POZN.: když step > 0 (wizard), intro necháme zůstat (žádný hide)
   }, [step, introState]);
 
   useEffect(() => {
@@ -669,9 +668,6 @@ export default function App() {
     };
 
     refreshPrimary();
-    getRedirectResult(auth).finally(() => {
-      refreshPrimary();
-    });
     onAuthStateChanged(auth, () => {
       refreshPrimary();
     });


### PR DESCRIPTION
## Summary
- keep intro splash visible during wizard steps and only fade when step=0
- remove duplicate getRedirectResult handling in gear menu

## Testing
- ⚠️ `npm test` *(missing script: test)*
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9f436f18083278f01283e53acc070