### PR TITLE
Use splash image for intro screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1672,9 +1672,7 @@ export default function App() {
     <>
       {/* Intro je VŽDY – u „starých“ fade-out po ~0.7s */}
       {introState !== 'hide' && (
-        <div className={`intro-screen ${introState==='fade' ? 'intro--fade' : ''}`}>
-          <img className="intro-logo" src="/logo.svg" alt="PutPing"/>
-        </div>
+        <div className={`intro-screen ${introState==='fade' ? 'intro--fade' : ''}`}></div>
       )}
 
       {/* app (mapa, FAB, markery…) až když step === 0 */}

--- a/src/index.css
+++ b/src/index.css
@@ -18,12 +18,10 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   position: fixed;
   inset: 0;
   width: 100vw; height: 100vh;
-  background: var(--pp-pink);
-  display:flex; align-items:center; justify-content:center;
+  background: center / cover no-repeat url('/splash.jpg');
   z-index: 2700;           /* pod onboarding panelem */
   pointer-events: none;
 }
-.intro-logo{ width: 180px; height:auto; opacity:.98; }
 
 /* Fade-out animace */
 .intro--fade{ animation: introFade .65s ease forwards; }


### PR DESCRIPTION
## Summary
- Replace pink intro overlay with background splash image
- Drop separate logo element and styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa03a598788327a946fdf42cfa2ccf