### PR TITLE
Hold splash for 2s before fading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -228,13 +228,19 @@ export default function App() {
 
   // 4) Neschovávej intro při step > 0 (zůstane jako pozadí wizardu)
   useEffect(() => {
+    let t1, t2;
     if (step === 0 && introState === 'show') {
-      // starý uživatel: krátký fade do mapy
-      setIntroState('fade');
-      const t = setTimeout(() => setIntroState('hide'), 800);
-      return () => clearTimeout(t);
+      // hotový uživatel: nech intro 2s a pak fade do mapy
+      t1 = setTimeout(() => setIntroState('fade'), 2000);
+    }
+    if (introState === 'fade') {
+      t2 = setTimeout(() => setIntroState('hide'), 800);
     }
     // POZN.: když step > 0 (wizard), intro necháme zůstat (žádný hide)
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
   }, [step, introState]);
 
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -24,7 +24,7 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 }
 
 /* Fade-out animace */
-.intro--fade{ animation: introFade .65s ease forwards; }
+.intro--fade{ animation: introFade 1s ease forwards; }
 @keyframes introFade{ to { opacity:0; } }
 
 /* Location consent modal */


### PR DESCRIPTION
## Summary
- Delay intro splash fade-out by 2 seconds for returning users
- Lengthen fade animation to 1s for a smoother transition

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aa05dbd550832799b13e7a91e553ea