### PR TITLE
fix: ensure FAB menu initializes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -624,9 +624,9 @@ export default function App() {
       gear.removeEventListener('pointerdown', onGearPointer);
       menu.removeEventListener('pointerdown', onMenuPointer);
       document.removeEventListener('pointerdown', onDocPointer);
-    document.removeEventListener('keydown', onKey);
-  };
-}, []);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [step]);
 
   // helper: proveď akci a zavři menu
   const withClose = (fn) => async (e) => {


### PR DESCRIPTION
## Summary
- ensure gear FAB menu initializes by rerunning effect when the onboarding step changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aa06caa9788327871f8aabbb9d123b