### PR TITLE
Ensure offline users are visible

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -758,9 +758,19 @@ export default function App() {
   }, [me, users]);
 
   useEffect(() => {
-    if (!me || !locationConsent) return;
-    if (!("geolocation" in navigator)) return;
+    if (!me) return;
     const meRef = ref(db, `users/${me.uid}`);
+
+    if (!locationConsent || !("geolocation" in navigator)) {
+      update(meRef, {
+        lat: null,
+        lng: null,
+        lastSeen: Date.now(),
+        online: false,
+      });
+      return;
+    }
+
     const opts = { enableHighAccuracy: true, maximumAge: 5000, timeout: 10000 };
 
     const updatePos = (pos) => {


### PR DESCRIPTION
## Summary
- Update geolocation effect so a user record is written even when location access is denied
- Preserve map visibility for users without geolocation consent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aab76707c483278ddd2f09e1d2743c