### PR TITLE
Allow authenticated read of users and owner write

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,13 @@
+{
+  "rules": {
+    ".read": false,
+    ".write": false,
+
+    "users": {
+      ".read": "auth != null",
+      "$uid": {
+        ".write": "auth != null && auth.uid === $uid"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow authenticated users to read `/users` in Realtime Database
- restrict writes to `/users/$uid` to the authenticated owner

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aac9dd85308327a00e663ff0384fd5