### PR TITLE
feat(ui): enable FAB again (remove false guard)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1702,27 +1702,26 @@ export default function App() {
                 </div>
               </div>
             )}
-            {false && (
-              <>
-                {/* Plovoucí menu (FAB) */}
-                <div
-                  style={{
-                    position: "absolute",
-                    bottom: 10,
-                    right: 10,
-                    zIndex: 10,
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "flex-end",
-                    gap: 8,
-                  }}
-                >
-                  {fabOpen && (
-                    <>
-                      <button
-                        onClick={() => {
-                          setShowSettings(true);
-                          setFabOpen(false);
+            <>
+              {/* Plovoucí menu (FAB) */}
+              <div
+                style={{
+                  position: "absolute",
+                  bottom: 10,
+                  right: 10,
+                  zIndex: 20,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-end",
+                  gap: 8,
+                }}
+              >
+                {fabOpen && (
+                  <>
+                    <button
+                      onClick={() => {
+                        setShowSettings(true);
+                        setFabOpen(false);
                         }}
                         style={{
                           width: 48,
@@ -1762,32 +1761,31 @@ export default function App() {
                           setShowChatList(true);
                           setFabOpen(false);
                         }}
-                        className="fab-chat"
-                        title="Minulé chaty"
-                      >
-                        💬
-                      </button>
-                    </>
-                  )}
-                  <button
-                    onClick={() => setFabOpen((o) => !o)}
-                    style={{
-                      width: 48,
-                      height: 48,
-                      borderRadius: 24,
-                      border: "1px solid #ddd",
-                      background: "#fff",
-                      cursor: "pointer",
-                      fontSize: 24,
-                      lineHeight: "24px",
-                    }}
-                    title="Menu"
-                  >
-                    {fabOpen ? "✖️" : "➕"}
-                  </button>
-                </div>
-              </>
-            )}
+                       className="fab-chat"
+                       title="Minulé chaty"
+                     >
+                       💬
+                     </button>
+                   </>
+                 )}
+                <button
+                  onClick={() => setFabOpen((o) => !o)}
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 24,
+                    border: "1px solid #ddd",
+                    background: "#fff",
+                    cursor: "pointer",
+                    fontSize: 24,
+                    lineHeight: "24px",
+                  }}
+                  title="Menu"
+                >
+                  {fabOpen ? "✖️" : "➕"}
+                </button>
+              </div>
+            </>
 
             {/* Mapa */}
             <div id="map" style={{ width: "100vw", height: "100vh" }} />


### PR DESCRIPTION
## Summary
- remove false guard around FAB so it renders again
- raise FAB container z-index to 20

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaca6f6cfc8327b75ad24188a14b0f