### PR TITLE
fix(intro): fade only when step===0

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -219,21 +219,13 @@ export default function App() {
     setStep(computeStep(me));
   }, [me]);  // ⬅ jakmile dorazí me z DB/cache, krok se srovná
 
-  // 4) Neschovávej intro při step > 0 (zůstane jako pozadí wizardu)
   useEffect(() => {
-    let t1, t2;
     if (step === 0 && introState === 'show') {
-      // hotový uživatel: nech intro 2s a pak fade do mapy
-      t1 = setTimeout(() => setIntroState('fade'), 2000);
+      setIntroState('fade');
+      const t = setTimeout(() => setIntroState('hide'), 800);
+      return () => clearTimeout(t);
     }
-    if (introState === 'fade') {
-      t2 = setTimeout(() => setIntroState('hide'), 800);
-    }
-    // POZN.: když step > 0 (wizard), intro necháme zůstat (žádný hide)
-    return () => {
-      clearTimeout(t1);
-      clearTimeout(t2);
-    };
+    // Když step > 0 (wizard), intro neschovávej – zůstává jako pozadí.
   }, [step, introState]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- simplify intro fade logic so fade starts immediately when step 0

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aacf64f85c8327bcaa3516feaa1ec7