### PR TITLE
feat(auth): show login errors so user isn’t stuck

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -282,13 +282,23 @@ export default function App() {
 
   // Google login (redirect – funguje i na iPhone)
   async function loginGoogle() {
-    const { GoogleAuthProvider, signInWithRedirect } = await import('firebase/auth');
-    await signInWithRedirect(auth, new GoogleAuthProvider());
+    try {
+      const { GoogleAuthProvider, signInWithRedirect } = await import('firebase/auth');
+      await signInWithRedirect(auth, new GoogleAuthProvider());
+    } catch (err) {
+      console.error('loginGoogle', err);
+      alert(err.code || err.message);
+    }
   }
   // anonymně (lze kdykoli později propojit s Googlem)
   async function loginAnon() {
-    const { signInAnonymously } = await import('firebase/auth');
-    await signInAnonymously(auth);
+    try {
+      const { signInAnonymously } = await import('firebase/auth');
+      await signInAnonymously(auth);
+    } catch (err) {
+      console.error('loginAnon', err);
+      alert(err.code || err.message);
+    }
   }
 
   function applyGenderRingInstant(uid, genderValue){


### PR DESCRIPTION
## Summary
- handle Google and anonymous login errors so users are notified instead of stuck

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aad966dbe08327a97aacf7684828a4