### PR TITLE
fix(profile): keep /publicProfiles in sync with location/lastSeen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -808,7 +808,7 @@ export default function App() {
 
     const opts = { enableHighAccuracy: true, maximumAge: 5000, timeout: 10000 };
 
-    const updatePos = (pos) => {
+    const updatePos = async (pos) => {
       const { latitude, longitude, accuracy } = pos.coords;
       console.log('My coords', latitude, longitude, 'accuracy', accuracy);
       // Ignore obviously wrong positions with extremely low accuracy (>10 km)
@@ -828,6 +828,7 @@ export default function App() {
         lastSeen: Date.now(),
         online: true,
       });
+      await upsertPublicProfile(me.uid, { lat: latitude, lng: longitude });
     };
     const handleErr = (err) => {
       console.warn("Geolocation error", err);


### PR DESCRIPTION
## Summary
- ensure publicProfiles reflect user location updates by calling `upsertPublicProfile` after geolocation saves

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aaf6c29e3083279d4b60e5d8dd5056