### PR TITLE
fix(auth): fallback getAuth() and single app init

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -338,9 +338,9 @@ export default function App() {
     try {
       const a = auth || getAuth();
       await signInWithRedirect(a, new GoogleAuthProvider());
-    } catch (err) {
-      console.error(err);
-      alert(err.code || err.message);
+    } catch (e) {
+      console.error('loginGoogle', e);
+      alert(e.code || e.message);
     }
   }
   // anonymně (lze kdykoli později propojit s Googlem)
@@ -348,9 +348,9 @@ export default function App() {
     try {
       const a = auth || getAuth();
       await signInAnonymously(a);
-    } catch (err) {
-      console.error(err);
-      alert(err.code || err.message);
+    } catch (e) {
+      console.error('loginAnon', e);
+      alert(e.code || e.message);
     }
   }
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,13 +1,9 @@
-// src/firebase.js				
+// src/firebase.js
 import { initializeApp, getApp, getApps } from "firebase/app";
 import { getDatabase } from "firebase/database";
-import {
-  getAuth,
-  browserLocalPersistence,
-  initializeAuth,
-} from "firebase/auth";
+import { getAuth } from "firebase/auth";
 import { getStorage, ref as sref, uploadBytes, getDownloadURL } from "firebase/storage";
-				
+
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
@@ -18,20 +14,13 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
-				
-const apps = getApps();
-const app = apps.length ? getApp() : initializeApp(firebaseConfig);
 
-const db = getDatabase(app);
-let auth;
-if (!apps.length) {
-  auth = initializeAuth(app, { persistence: browserLocalPersistence });
-} else {
-  auth = getAuth(app);
-}
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);
+export const db = getDatabase(app);
 export const storage = getStorage(app);
 
-const initSecondaryApp = (name) => initializeApp(firebaseConfig, name);
+export const initSecondaryApp = (name) => initializeApp(firebaseConfig, name);
 
-export { db, firebaseConfig, initSecondaryApp, auth };
-export { sref, uploadBytes, getDownloadURL };
+export { firebaseConfig, sref, uploadBytes, getDownloadURL };


### PR DESCRIPTION
## Summary
- handle auth errors with function-specific logging
- ensure Firebase uses a single initialized app instance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aafabad4e8832799cea9751d209039