### PR TITLE
feat(profile): one-time backfill /publicProfiles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -285,6 +285,23 @@ export default function App() {
     document.documentElement.classList.toggle('sheet-open', showSettings);
   }, [showSettings]);
 
+  // jednorázový backfill publicProfiles
+  useEffect(() => {
+    const uid = auth.currentUser?.uid; if (!uid) return;
+    get(ref(db, `publicProfiles/${uid}`)).then(s => {
+      if (s.exists()) return;
+      return get(ref(db, `users/${uid}`)).then(s2 => {
+        const u = s2.val() || {};
+        return upsertPublicProfile(uid, {
+          name: u.name || 'Anonym',
+          gender: u.gender || 'any',
+          photoURL: u.photoURL || '',
+          lat: u.lat ?? 0, lng: u.lng ?? 0
+        });
+      });
+    }).catch(console.error);
+  }, [auth.currentUser?.uid]);
+
   const mapInitedRef = useRef(false);
   useEffect(() => {
     if (step > 0 || mapInitedRef.current) return;


### PR DESCRIPTION
## Summary
- add migration effect to backfill `/publicProfiles` from existing `users` data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aafb6e7f908327ba6430fe43e60e63