### PR TITLE
chore: sync public location only for complete profiles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -868,13 +868,12 @@ export default function App() {
         lastSeen: Date.now(),
         online: true,
       });
-      await upsertPublicProfile(me.uid, {
-        name: me.name,
-        gender: me.gender,
-        photoURL: me.photoURL,
-        lat: latitude,
-        lng: longitude,
-      });
+      if (isProfileComplete(me)) {
+        await upsertPublicProfile(me.uid, {
+          lat: latitude,
+          lng: longitude,
+        });
+      }
     };
     const handleErr = (err) => {
       console.warn("Geolocation error", err);


### PR DESCRIPTION
## Summary
- write location to `publicProfiles` only when profile is complete

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab02a2fc008327933211da4dd5edb7