### PR TITLE
fix(onboarding): validate and persist before leaving

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -409,8 +409,18 @@ export default function App() {
     setStep(computeStep());
   }
 
-  function finishOnboard(){
-    setStep(computeStep());
+  async function finishOnboard(){
+    const u = me || {};
+    const ok = !!(u.name && u.gender && u.photoURL);
+    if (!ok) { alert('Doplň jméno, pohlaví a fotku.'); return; }
+    try {
+      await saveProfile(u.uid, {
+        name: u.name, gender: u.gender, photoURL: u.photoURL,
+        age: u.age ?? null
+      });
+      localStorage.setItem('pp_onboard_v1', '1');
+      setStep(0);
+    } catch(e){ console.error(e); alert(e.code||e.message); }
   }
 
   function RenderSettingsFields(){


### PR DESCRIPTION
## Summary
- validate user profile before finishing onboarding
- persist profile data and mark onboarding completion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab0b5b8e7c8327acc93a5e9e821a81