### PR TITLE
feat(profile): prime local state after auth

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -276,7 +276,13 @@ export default function App() {
     const unsub = onAuthStateChanged(a, async (user) => {
       setAuthed(!!user);
       if (!user) { setStep(2); return; }
-      const uid = user.uid;
+      const uid = user?.uid;
+      if (uid) {
+        const cached = readProfileCache(uid) || {};
+        const initial = { uid, ...cached, pingPrefs: cached.pingPrefs || {} };
+        setMe(initial);
+        meGlobal = initial;
+      }
       const uRef = ref(db, 'users/'+uid);
       const us = await get(uRef);
       if (!us.exists()) {


### PR DESCRIPTION
## Summary
- prime local profile state with cached data after auth to prevent null inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab0cad06448327a83cfdf11b2196a6