### PR TITLE
fix(onboarding): enable taps and focus on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -776,3 +776,15 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
 
 .pill{ padding:10px 12px; border-radius:12px; border:1px solid rgba(122,40,69,.25); cursor:pointer; background:#fff; }
 .pill.active{ box-shadow: 0 0 0 2px #fff, 0 0 0 4px #EC4899; border-color: transparent; } /* MUŽ = růžový obdélník */
+
+/* Onboarding: vždy propusť tapy dovnitř karty */
+.onboard, .onboard * { touch-action: manipulation; }
+.onboard-card, .onboard-card * { pointer-events: auto !important; }
+
+/* Vstupy musí být focusovatelné i na iOS */
+input, textarea, select, button { -webkit-tap-highlight-color: transparent; }
+input, textarea { -webkit-user-select: text; user-select: text; }
+
+/* Bezpečí: skryté vrstvy, které nejsou otevřené, nesmí chytat události */
+.gear-menu:not(.open), .chat-panel.hidden { pointer-events: none; }
+


### PR DESCRIPTION
## Summary
- allow onboarding card taps and pointer events on mobile
- ensure inputs on iOS can receive focus and text selection
- prevent hidden layers from intercepting pointer events

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab1399f93c83279ecce3c8baf0393c