### PR TITLE
fix(onboarding): validate & persist before leaving

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -420,15 +420,13 @@ export default function App() {
   async function finishOnboard(){
     const u = me || {};
     const ok = !!(u.name && u.gender && u.photoURL);
-    if (!ok) { alert('Doplň jméno, pohlaví a fotku.'); return; }
-    try {
-      await saveProfile(u.uid, {
-        name: u.name, gender: u.gender, photoURL: u.photoURL,
-        age: u.age ?? null
-      });
-      localStorage.setItem('pp_onboard_v1', '1');
+    if (!ok){ alert('Doplň jméno, pohlaví a fotku.'); return; }
+    try{
+      await saveProfile(u.uid, { name:u.name, gender:u.gender, photoURL:u.photoURL, age: u.age ?? null });
+      await update(ref(db, 'publicProfiles/'+u.uid), { name:u.name, gender:u.gender, photoURL:u.photoURL, lastSeen: Date.now() });
+      localStorage.setItem('pp_onboard_v1','1');
       setStep(0);
-    } catch(e){ console.error(e); alert(e.code||e.message); }
+    }catch(e){ console.error(e); alert(e.code||e.message); }
   }
 
   function scrollIntoViewOnFocus(el){


### PR DESCRIPTION
## Summary
- ensure onboarding validates mandatory fields before finishing
- persist user profile and public profile before exiting onboarding

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1670df9c8327ac638b3aa4e472bf