### PR TITLE
Zakaž intro overlay mimo mapu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1817,9 +1817,9 @@ export default function App() {
 
   return (
     <>
-      {/* Intro je VŽDY – u „starých“ fade-out po ~0.7s */}
-      {introState !== 'hide' && (
-        <div className={`intro-screen ${introState==='fade' ? 'intro--fade' : ''}`}></div>
+      {/* Intro jen na mapě (step 0) – u „starých“ fade-out po ~0.7s */}
+      {(step === 0 && introState !== 'hide') && (
+        <div className={`intro-screen ${introState==='fade' ? 'intro--fade' : ''}`} />
       )}
 
       {/* app (mapa, FAB, markery…) */}


### PR DESCRIPTION
## Summary
- render intro overlay only on step 0 to keep splash off non-map screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1902dce08327b49e918200ca58d2