### PR TITLE
Propusť tapy na onboard kartě (CSS)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -788,3 +788,9 @@ input, textarea { -webkit-user-select: text; user-select: text; }
 /* Bezpečí: skryté vrstvy, které nejsou otevřené, nesmí chytat události */
 .gear-menu:not(.open), .chat-panel.hidden { pointer-events: none; }
 
+/* Onboarding musí být nad vším a klikatelný */
+.onboard{ z-index:3000; }
+.onboard, .onboard * { pointer-events:auto !important; touch-action: manipulation; }
+
+/* Splash nesmí chytat události (když by se náhodou vykreslil) */
+.intro-screen{ pointer-events:none; }


### PR DESCRIPTION
## Summary
- ensure onboarding overlay remains interactive and above all layers
- prevent splash screen from capturing events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab19d521a08327b2568ce16374efb8