### PR TITLE
fix(ui): hide FAB while onboarding to avoid tap overlap

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1839,89 +1839,91 @@ export default function App() {
                 </div>
               </div>
             )}
-            <>
+            <> 
               {/* Plovoucí menu (FAB) */}
-              <div
-                style={{
-                  position: "absolute",
-                  bottom: 10,
-                  right: 10,
-                  zIndex: 20,
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "flex-end",
-                  gap: 8,
-                }}
-              >
-                {fabOpen && (
-                  <>
-                    <button
-                      onClick={() => {
-                        setShowSettings(true);
-                        setFabOpen(false);
-                      }}
-                      style={{
-                        width: 48,
-                        height: 48,
-                        borderRadius: 24,
-                        border: "1px solid #ddd",
-                        background: "transparent",
-                        cursor: "pointer",
-                        fontSize: 24,
-                        lineHeight: "24px",
-                      }}
-                      title="Nastavení"
-                    >
-                      ⚙️
-                    </button>
-                    <button
-                      onClick={() => {
-                        setShowGallery(true);
-                        setFabOpen(false);
-                      }}
-                      style={{
-                        width: 48,
-                        height: 48,
-                        borderRadius: 24,
-                        border: "1px solid #ddd",
-                        background: "transparent",
-                        cursor: "pointer",
-                        fontSize: 24,
-                        lineHeight: "24px",
-                      }}
-                      title="Galerie"
-                    >
-                      🖼️
-                    </button>
-                    <button
-                      onClick={() => {
-                        setShowChatList(true);
-                        setFabOpen(false);
-                      }}
-                      className="fab-chat"
-                      title="Minulé chaty"
-                    >
-                      💬
-                    </button>
-                  </>
-                )}
-                <button
-                  onClick={() => setFabOpen((o) => !o)}
+              {step === 0 && (
+                <div
                   style={{
-                    width: 48,
-                    height: 48,
-                    borderRadius: 24,
-                    border: "1px solid #ddd",
-                    background: "#fff",
-                    cursor: "pointer",
-                    fontSize: 24,
-                    lineHeight: "24px",
+                    position: "absolute",
+                    bottom: 10,
+                    right: 10,
+                    zIndex: 20,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "flex-end",
+                    gap: 8,
                   }}
-                  title="Menu"
                 >
-                  {fabOpen ? "✖️" : "➕"}
-                </button>
-              </div>
+                  {fabOpen && (
+                    <>
+                      <button
+                        onClick={() => {
+                          setShowSettings(true);
+                          setFabOpen(false);
+                        }}
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 24,
+                          border: "1px solid #ddd",
+                          background: "transparent",
+                          cursor: "pointer",
+                          fontSize: 24,
+                          lineHeight: "24px",
+                        }}
+                        title="Nastavení"
+                      >
+                        ⚙️
+                      </button>
+                      <button
+                        onClick={() => {
+                          setShowGallery(true);
+                          setFabOpen(false);
+                        }}
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 24,
+                          border: "1px solid #ddd",
+                          background: "transparent",
+                          cursor: "pointer",
+                          fontSize: 24,
+                          lineHeight: "24px",
+                        }}
+                        title="Galerie"
+                      >
+                        🖼️
+                      </button>
+                      <button
+                        onClick={() => {
+                          setShowChatList(true);
+                          setFabOpen(false);
+                        }}
+                        className="fab-chat"
+                        title="Minulé chaty"
+                      >
+                        💬
+                      </button>
+                    </>
+                  )}
+                  <button
+                    onClick={() => setFabOpen((o) => !o)}
+                    style={{
+                      width: 48,
+                      height: 48,
+                      borderRadius: 24,
+                      border: "1px solid #ddd",
+                      background: "#fff",
+                      cursor: "pointer",
+                      fontSize: 24,
+                      lineHeight: "24px",
+                    }}
+                    title="Menu"
+                  >
+                    {fabOpen ? "✖️" : "➕"}
+                  </button>
+                </div>
+              )}
             </>
 
             {/* Mapa */}


### PR DESCRIPTION
## Summary
- Render FAB only after onboarding so it doesn't overlap onboarding inputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab2162e2408327b1faf982245876c8