### PR TITLE
fix(onboarding): ensure inputs are focusable on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -794,3 +794,10 @@ input, textarea { -webkit-user-select: text; user-select: text; }
 
 /* Splash nesmí chytat události (když by se náhodou vykreslil) */
 .intro-screen{ pointer-events:none; }
+/* Onboarding nad vším a klikací */
+.onboard { z-index: 9999; pointer-events: auto; }
+.onboard-card { z-index: 10000; pointer-events: auto; position: relative; }
+.onboard-card * { pointer-events: auto; }
+
+/* Splash (intro) nesmí chytat události */
+.intro-screen { pointer-events: none !important; }


### PR DESCRIPTION
## Summary
- Raise onboarding overlay z-index and enable pointer events so cards and inputs remain clickable
- Prevent intro splash from capturing pointer events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab22dccd70832795825b27ce0f71c9