### PR TITLE
fix(svg markers): avoid ID collisions

### DIFF
--- a/src/MapPinMarker.tsx
+++ b/src/MapPinMarker.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useId } from "react";
 
 interface MapPinMarkerProps {
   onPing?: () => void;
 }
 
 const MapPinMarker: React.FC<MapPinMarkerProps> = ({ onPing }) => {
+  const gradientId = useId();
+
   return (
     <svg
       width={80}
@@ -13,14 +15,14 @@ const MapPinMarker: React.FC<MapPinMarkerProps> = ({ onPing }) => {
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs>
-        <linearGradient id="pinGradient" x1="0" y1="0" x2="0" y2="1">
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="#FF3366" />
           <stop offset="100%" stopColor="#FF6F91" />
         </linearGradient>
       </defs>
       <path
         d="M40 0C62 0 80 18 80 40C80 73 40 112 40 112C40 112 0 73 0 40C0 18 18 0 40 0Z"
-        fill="url(#pinGradient)"
+        fill={`url(#${gradientId})`}
       />
       <g
         onClick={() => onPing && onPing()}

--- a/src/PinSVG.tsx
+++ b/src/PinSVG.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useId } from "react";
 
 interface PinSVGProps {
   photoUrl: string;
@@ -8,12 +8,20 @@ interface PinSVGProps {
 
 const PinSVG: React.FC<PinSVGProps> = ({ photoUrl, name, onPing }) => {
   const [mode, setMode] = useState<"ping" | "chat">("ping");
+  const id = useId();
+
+  const pinGradientId = `pinGradient-${id}`;
+  const pingButtonGradientId = `pingButtonGradient-${id}`;
+  const chatButtonGradientId = `chatButtonGradient-${id}`;
+  const photoClipId = `photoClip-${id}`;
+  const shadowId = `shadow-${id}`;
+
   const handleClick = () => {
     if (mode === "ping" && onPing) onPing();
     setMode((m) => (m === "ping" ? "chat" : "ping"));
   };
 
-  const buttonGradient = mode === "ping" ? "pingButtonGradient" : "chatButtonGradient";
+  const buttonGradient = mode === "ping" ? pingButtonGradientId : chatButtonGradientId;
   const aria = mode === "ping" ? "Ping user" : "Chat with user";
 
   return (
@@ -24,29 +32,29 @@ const PinSVG: React.FC<PinSVGProps> = ({ photoUrl, name, onPing }) => {
       xmlns="http://www.w3.org/2000/svg"
     >
       <defs>
-        <linearGradient id="pinGradient" x1="0" y1="0" x2="0" y2="1">
+        <linearGradient id={pinGradientId} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="#FF3366" />
           <stop offset="100%" stopColor="#FF6F91" />
         </linearGradient>
-        <linearGradient id="pingButtonGradient" x1="0" y1="0" x2="0" y2="1">
+        <linearGradient id={pingButtonGradientId} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="#FF3366" />
           <stop offset="100%" stopColor="#FF6F91" />
         </linearGradient>
-        <linearGradient id="chatButtonGradient" x1="0" y1="0" x2="0" y2="1">
+        <linearGradient id={chatButtonGradientId} x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="#3B82F6" />
           <stop offset="100%" stopColor="#60A5FA" />
         </linearGradient>
-        <clipPath id="photoClip">
+        <clipPath id={photoClipId}>
           <circle cx="120" cy="120" r="90" />
         </clipPath>
-        <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+        <filter id={shadowId} x="-20%" y="-20%" width="140%" height="140%">
           <feDropShadow dx="0" dy="4" stdDeviation="4" floodOpacity="0.2" />
         </filter>
       </defs>
       <path
         d="M120 0C186 0 240 54 240 120C240 220 120 320 120 320C120 320 0 220 0 120C0 54 54 0 120 0Z"
-        fill="url(#pinGradient)"
-        filter="url(#shadow)"
+        fill={`url(#${pinGradientId})`}
+        filter={`url(#${shadowId})`}
       />
       <image
         href={photoUrl}
@@ -54,7 +62,7 @@ const PinSVG: React.FC<PinSVGProps> = ({ photoUrl, name, onPing }) => {
         y="30"
         width="180"
         height="180"
-        clipPath="url(#photoClip)"
+        clipPath={`url(#${photoClipId})`}
         preserveAspectRatio="xMidYMid slice"
       />
       <circle

--- a/src/UserPin.tsx
+++ b/src/UserPin.tsx
@@ -1,50 +1,56 @@
-import React from "react";
+import React, { useId } from "react";
 
 interface UserPinProps {
   photoUrl: string;
   name: string;
 }
 
-const UserPin: React.FC<UserPinProps> = ({ photoUrl, name }) => (
-  <div className="pin-wrapper">
-    <svg width={80} height={112} viewBox="0 0 80 112" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <linearGradient id="pinkGradient" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#FF3366" />
-          <stop offset="100%" stopColor="#FF6F91" />
-        </linearGradient>
-        <clipPath id="clipCircle">
-          <circle cx="40" cy="32" r="24" />
-        </clipPath>
-      </defs>
-      <path
-        d="M40 0C62 0 80 18 80 40C80 73 40 112 40 112C40 112 0 73 0 40C0 18 18 0 40 0Z"
-        fill="url(#pinkGradient)"
-      />
-      <image
-        href={photoUrl}
-        x="16"
-        y="8"
-        width="48"
-        height="48"
-        clipPath="url(#clipCircle)"
-        preserveAspectRatio="xMidYMid slice"
-      />
-      <circle cx="40" cy="32" r="24" fill="none" stroke="#FFF" strokeWidth="3" />
-      <text
-        x="40"
-        y="84"
-        textAnchor="middle"
-        fontSize="12"
-        fontFamily="sans-serif"
-        fill="#FFF"
-      >
-        {name}
-      </text>
-    </svg>
-    <button className="chat-btn">Chat</button>
-  </div>
-);
+const UserPin: React.FC<UserPinProps> = ({ photoUrl, name }) => {
+  const id = useId();
+  const gradientId = `pinkGradient-${id}`;
+  const clipId = `clipCircle-${id}`;
+
+  return (
+    <div className="pin-wrapper">
+      <svg width={80} height={112} viewBox="0 0 80 112" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#FF3366" />
+            <stop offset="100%" stopColor="#FF6F91" />
+          </linearGradient>
+          <clipPath id={clipId}>
+            <circle cx="40" cy="32" r="24" />
+          </clipPath>
+        </defs>
+        <path
+          d="M40 0C62 0 80 18 80 40C80 73 40 112 40 112C40 112 0 73 0 40C0 18 18 0 40 0Z"
+          fill={`url(#${gradientId})`}
+        />
+        <image
+          href={photoUrl}
+          x="16"
+          y="8"
+          width="48"
+          height="48"
+          clipPath={`url(#${clipId})`}
+          preserveAspectRatio="xMidYMid slice"
+        />
+        <circle cx="40" cy="32" r="24" fill="none" stroke="#FFF" strokeWidth="3" />
+        <text
+          x="40"
+          y="84"
+          textAnchor="middle"
+          fontSize="12"
+          fontFamily="sans-serif"
+          fill="#FFF"
+        >
+          {name}
+        </text>
+      </svg>
+      <button className="chat-btn">Chat</button>
+    </div>
+  );
+};
 
 export default UserPin;
 


### PR DESCRIPTION
## Summary
- generate unique gradient and clip-path IDs for SVG markers to ensure they render correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab28cb98388327972254796d6b521a