### PR TITLE
Fix marker display by sanitizing SVG ids

### DIFF
--- a/src/MapPinMarker.tsx
+++ b/src/MapPinMarker.tsx
@@ -5,7 +5,8 @@ interface MapPinMarkerProps {
 }
 
 const MapPinMarker: React.FC<MapPinMarkerProps> = ({ onPing }) => {
-  const gradientId = useId();
+  const rawId = useId();
+  const gradientId = `markerGradient-${rawId.replace(/:/g, "")}`;
 
   return (
     <svg

--- a/src/PinSVG.tsx
+++ b/src/PinSVG.tsx
@@ -8,13 +8,13 @@ interface PinSVGProps {
 
 const PinSVG: React.FC<PinSVGProps> = ({ photoUrl, name, onPing }) => {
   const [mode, setMode] = useState<"ping" | "chat">("ping");
-  const id = useId();
+  const rawId = useId().replace(/:/g, "");
 
-  const pinGradientId = `pinGradient-${id}`;
-  const pingButtonGradientId = `pingButtonGradient-${id}`;
-  const chatButtonGradientId = `chatButtonGradient-${id}`;
-  const photoClipId = `photoClip-${id}`;
-  const shadowId = `shadow-${id}`;
+  const pinGradientId = `pinGradient-${rawId}`;
+  const pingButtonGradientId = `pingButtonGradient-${rawId}`;
+  const chatButtonGradientId = `chatButtonGradient-${rawId}`;
+  const photoClipId = `photoClip-${rawId}`;
+  const shadowId = `shadow-${rawId}`;
 
   const handleClick = () => {
     if (mode === "ping" && onPing) onPing();

--- a/src/UserPin.tsx
+++ b/src/UserPin.tsx
@@ -6,9 +6,9 @@ interface UserPinProps {
 }
 
 const UserPin: React.FC<UserPinProps> = ({ photoUrl, name }) => {
-  const id = useId();
-  const gradientId = `pinkGradient-${id}`;
-  const clipId = `clipCircle-${id}`;
+  const rawId = useId().replace(/:/g, "");
+  const gradientId = `pinkGradient-${rawId}`;
+  const clipId = `clipCircle-${rawId}`;
 
   return (
     <div className="pin-wrapper">


### PR DESCRIPTION
## Summary
- sanitize ids returned by useId for marker gradients and clip paths to avoid invalid characters that prevent markers from rendering

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab345ef4848327ae478f366af5ce52