### PR TITLE
feat: non-blocking splash with fade-out

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,13 +76,21 @@ export default function App() {
   const [showChatList, setShowChatList] = useState(false);
   const [showGallery, setShowGallery] = useState(false);
   const [deleteIdx, setDeleteIdx] = useState(null);
-  const [showIntro, setShowIntro] = useState(true);
-  const [fadeIntro, setFadeIntro] = useState(false);
+  const [introState, setIntroState] = useState('show');
   const [markerHighlights, setMarkerHighlights] = useState({}); // uid -> color
   const [locationConsent, setLocationConsent] = useState(() =>
     localStorage.getItem("locationConsent") === "1"
   );
   const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setIntroState('fade'), 800);
+    const t2 = setTimeout(() => setIntroState('hide'), 1700);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, []);
 
   // ref pro nejnovější zvýraznění markerů
   const markerHighlightsRef = useRef({});
@@ -958,8 +966,8 @@ export default function App() {
 
   /* ──────────────────────────────── Render UI ───────────────────────────── */
 
-  return (
-    <div>
+    return (
+      <div id="appRoot">
       {isIOS && !locationConsent && (
         <div className="consent-modal">
           <div className="consent-modal__content">
@@ -1054,8 +1062,8 @@ export default function App() {
         </button>
       </div>
 
-      {/* Mapa */}
-      <div id="map" style={{ width: "100vw", height: "100vh" }} />
+        {/* Mapa */}
+        <div id="map" />
 
       {false && showChatList && (
         <div className="chat-list">
@@ -1469,17 +1477,11 @@ export default function App() {
           </div>
         </div>
       )}
-      {false && showIntro && (
-        <div
-          className={`intro-screen ${fadeIntro ? "intro-screen--hidden" : ""}`}
-          onClick={() => {
-            setFadeIntro(true);
-            setTimeout(() => setShowIntro(false), 500);
-          }}
-        >
-          <img src="/splash.jpg" alt="PutPing" className="intro-screen__img" />
-        </div>
-      )}
-    </div>
-  );
-}
+        {(step===0 && introState!=='hide') && (
+          <div className={`intro-screen ${introState==='fade'?'intro--fade':''}`}>
+            <div className="intro-logo">PutPing</div>
+          </div>
+        )}
+      </div>
+    );
+  }

--- a/src/index.css
+++ b/src/index.css
@@ -3,30 +3,6 @@
 html, body, #root { height: 100%; }
 body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; color: #111827; }
 
-/* Map container */
-.map { width: 100vw; height: 100vh; }
-
-/* Intro splash */
-.intro-screen {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  transition: opacity 0.5s ease;
-  padding: 7mm;
-  background: #ff8fa1;
-}
-.intro-screen--hidden {
-  opacity: 0;
-}
-.intro-screen__img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
 /* Location consent modal */
 .consent-modal {
   position: fixed;
@@ -475,3 +451,17 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   left: 50%;
   transform: translateX(-50%);
 }
+
+html,body,#root{height:100%;margin:0}
+#appRoot{position:fixed; inset:0}
+#map{position:absolute; inset:0}
+
+.intro-screen{
+  position:fixed; inset:0; z-index:5;
+  display:flex; align-items:center; justify-content:center;
+  background:linear-gradient(180deg,#f5a4b3 0%,#f2a0af 100%);
+  opacity:1; transition:opacity .7s ease;
+  pointer-events:none; /* nikdy neblokuje kliky */
+}
+.intro-screen.intro--fade{ opacity:0; }
+.intro-logo{ font-size:40px; font-weight:800; color:#1a1a1a; }


### PR DESCRIPTION
## Summary
- introduce `introState` to drive timed fade-out splash
- add fixed `#appRoot` and absolute `#map` containers
- style splash to never intercept clicks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab7dd2cbcc8327aa4dd65ecd76f10c