### PR TITLE
fix(markers): read from /publicProfiles instead of /users

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -736,8 +736,10 @@ export default function App() {
   useEffect(() => {
     if (!map || !me) return;
 
-    const usersRef = ref(db, "users");
-    const unsub = onValue(usersRef, (snap) => {
+    const profilesRef = ref(db, "publicProfiles");
+    const unsub = onValue(
+      profilesRef,
+      (snap) => {
       const data = snap.val() || {};
       // Firebase RTDB may return arrays as objects; ensure photos are arrays
       Object.values(data).forEach((u) => {
@@ -882,7 +884,9 @@ export default function App() {
           delete markers.current[uid];
         }
       });
-    });
+      },
+      (err) => console.warn("publicProfiles stream error:", err?.code || err)
+    );
 
     return () => unsub();
   }, [map, me]);


### PR DESCRIPTION
## Summary
- switch map markers stream to `/publicProfiles`
- log stream errors for easier debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac46b294788327aed987da726e0984