### PR TITLE
feat: restore gender normalization in canPing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -125,15 +125,26 @@ async function compressImage(file, maxDim = 800, quality = 0.8) {
   return blob;
 }
 
-function canPing(viewer, target){
-  if (!target) return true;
-  const prefs = target.pingPrefs || { gender:'any', minAge:16, maxAge:100 };
-  if (prefs.gender === 'm' && viewer?.gender !== 'm') return false;
-  if (prefs.gender === 'f' && viewer?.gender !== 'f') return false;
-  const age = viewer?.age;
-  if (typeof age !== 'number') return false;
+function normGender(g) {
+  const s = (g ?? '').toString().trim().toLowerCase();
+  if (["m", "male", "man", "muž", "muz", "kluk", "boy"].includes(s)) return "m";
+  if (["f", "female", "woman", "žena", "zena", "holka", "girl"].includes(s)) return "f";
+  return "any";
+}
+
+function canPing(viewer = {}, target = {}) {
+  const prefs = target.pingPrefs || { gender: "any", minAge: 16, maxAge: 100 };
+
+  const vg = normGender(viewer.gender);
+  if (prefs.gender === "m" && vg !== "m") return false;
+  if (prefs.gender === "f" && vg !== "f") return false;
+
+  const age = Number(viewer.age);
+  if (!Number.isFinite(age)) return true;
+
   if (age < (prefs.minAge ?? 16)) return false;
   if (age > (prefs.maxAge ?? 100)) return false;
+
   return true;
 }
 


### PR DESCRIPTION
## Summary
- add `normGender` helper to standardize gender terms
- permit pings when viewer age is missing by relying on normalized gender

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac5f6a30f88327886a2ea2e8541e04