### PR TITLE
fix(map): fullscreen height + Mapbox token fallback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,16 @@ import { getRedirectResult, signOut } from "firebase/auth";
 
 /* ───────────────────────────────── Mapbox ────────────────────────────────── */
 
-mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
+if (!mapboxgl.accessToken) {
+  mapboxgl.accessToken =
+    (import.meta?.env?.VITE_MAPBOX_TOKEN) ||
+    (typeof window !== 'undefined' ? window.MAPBOX_TOKEN : '') ||
+    '';
+  if (!mapboxgl.accessToken) {
+    console.warn('Mapbox access token is missing (VITE_MAPBOX_TOKEN / window.MAPBOX_TOKEN).');
+    // optional: alert('Chybí Mapbox token – nastav VITE_MAPBOX_TOKEN v Netlify Environment Variables.');
+  }
+}
 
 window.shouldPlaySound = () =>
   localStorage.getItem("soundEnabled") !== "0";

--- a/src/index.css
+++ b/src/index.css
@@ -745,3 +745,8 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   z-index: -1;                     /* pod obsahem bubliny */
   pointer-events: none;
 }
+
+/* --- Map fullscreen baseline --- */
+html, body, #root { height: 100%; margin: 0; }
+#appRoot { position: fixed; inset: 0; }
+#map { position: absolute; inset: 0; }


### PR DESCRIPTION
## Summary
- ensure map fills viewport by enforcing html/body/root height and positioning app and map roots
- add Mapbox access token fallback to read from Vite env or window token and warn if missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac72ac443c8327b4652f8155f9f5c8