### PR TITLE
fix: keep map markers anchored during zoom

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -897,7 +897,6 @@ export default function App() {
         if (!markers.current[uid]) {
           const wrapper = document.createElement("div");
           wrapper.className = "marker-wrapper";
-          wrapper.style.transformOrigin = "bottom center";
           wrapper.style.setProperty('--ring-color', getGenderRing(u) || 'transparent');
           const ring = document.createElement('div');
           ring.className = 'marker-ring';


### PR DESCRIPTION
## Summary
- ensure map markers stay anchored when zooming out by removing unnecessary transform-origin

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f1acb4083279a5dbfaf99b4e99f