### PR TITLE
Center user marker on map

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -790,6 +790,9 @@ export default function App() {
         lastActive: Date.now(),
         online: true,
       });
+      // keep my marker and map centered on my current location
+      markers.current[me.uid]?.setLngLat([longitude, latitude]);
+      map?.setCenter([longitude, latitude]);
     };
     const handleErr = (err) => {
       console.warn("Geolocation error", err);
@@ -806,7 +809,7 @@ export default function App() {
     const id = navigator.geolocation.watchPosition(updatePos, handleErr, opts);
 
     return () => navigator.geolocation.clearWatch(id);
-  }, [me, locationConsent]);
+  }, [me, locationConsent, map]);
 
   /* ───────────────────────────── Init mapy ──────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Keep user marker and map centered on the user's latest location

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd673401d48327887e7397068f246c