### PR TITLE
Fix map centering and add bot pulse animation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -79,6 +79,15 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-
   0%, 100% { transform: scale(1); }
   50% { transform: scale(5); }
 }
+.marker-avatar.bot-pulse {
+  animation: bot-pulse 1s ease-in-out infinite;
+  filter: brightness(0.7);
+}
+
+@keyframes bot-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(2); }
+}
 .marker-bubble {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
## Summary
- persist geolocation updates to profile and local storage
- center map using cached coordinates on startup
- add dark pulsing animation for dev bot markers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd6ed5a7508327bb429bb62c4d61e3